### PR TITLE
Quick fix for node18 user experience

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -9,6 +9,6 @@ export const PKG_ROOT = path.join(distPath, "../");
 
 //export const PKG_ROOT = path.dirname(require.main.filename);
 
-export const TITLE_TEXT = `Welcome to the create-t3-app !`;
+export const TITLE_TEXT = `CREATE T3 APP`;
 export const DEFAULT_APP_NAME = "my-t3-app";
 export const CREATE_T3_APP = "create-t3-app";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,14 +13,6 @@ import { renderTitle } from "./utils/renderTitle.js";
 const main = async () => {
   renderTitle();
 
-  // TEMPORARY WARNING WHEN USING NODE 18. SEE ISSUE #59
-  if (process.versions.node.startsWith("18")) {
-    logger.warn(`  WARNING: You are using Node.js version 18. This is currently not compatible with Next-Auth.
-  If you want to use Next-Auth, switch to a previous version of Node, e.g. 16 (LTS).
-  If you have nvm installed, use 'nvm install --lts' to switch to the latest LTS version of Node.
-    `);
-  }
-
   const {
     appName,
     packages,

--- a/src/utils/renderTitle.ts
+++ b/src/utils/renderTitle.ts
@@ -1,5 +1,6 @@
 import figlet from "figlet";
 import gradient from "gradient-string";
+import { TITLE_TEXT } from "../consts.js";
 
 // colors brought in from vscode poimandres theme
 const poimandresTheme = {
@@ -12,7 +13,7 @@ const poimandresTheme = {
 };
 
 export const renderTitle = () => {
-  const text = figlet.textSync("CREATE T3 APP", { font: "Small" });
+  const text = figlet.textSync(TITLE_TEXT, { font: "Small" });
   const t3Gradient = gradient(Object.values(poimandresTheme));
   console.log(t3Gradient.multiline(text));
 };


### PR DESCRIPTION
Reenable the --version flag (good for issue tracking in case a user has an old ct3a in their global installs)

Only show the node18 warning if the user isn't using the --help or --version flags

Automatically change the 'defaultOptions' object is the user is using node18 (remove next-auth)