### PR TITLE
fix-feat: extend validate app name to support paths and scoped packages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { initializeGit } from "./helpers/initGit.js";
 import { logNextSteps } from "./helpers/logNextSteps.js";
 import { buildPkgInstallerMap } from "./installers/index.js";
 import { logger } from "./utils/logger.js";
+import { parseNameAndPath } from "./utils/parseNameAndPath.js";
 import { renderTitle } from "./utils/renderTitle.js";
 
 const main = async () => {
@@ -29,18 +30,21 @@ const main = async () => {
 
   const usePackages = buildPkgInstallerMap(packages);
 
-  const projectDir = await createProject(appName, usePackages);
+  // e.g. dir/@mono/app returns ["@mono/app", "dir/app"]
+  const [scopedAppName, appDir] = parseNameAndPath(appName);
+
+  const projectDir = await createProject(appDir, usePackages);
 
   if (!noGit) {
     await initializeGit(projectDir);
   }
 
-  logNextSteps(appName, usePackages);
+  logNextSteps(appDir, usePackages);
 
   const pkgJson = (await fs.readJSON(
     path.join(projectDir, "package.json"),
   )) as PackageJson;
-  pkgJson.name = appName;
+  pkgJson.name = scopedAppName;
   await fs.writeJSON(path.join(projectDir, "package.json"), pkgJson, {
     spaces: 2,
   });

--- a/src/utils/parseNameAndPath.ts
+++ b/src/utils/parseNameAndPath.ts
@@ -1,0 +1,24 @@
+/**
+ *  Parses the appName and its path from the user input.
+ * Returns an array of [appName, path] where appName is the name put in the package.json and
+ *   path is the path to the directory where the app will be created.
+ * Handles the case where the input includes a scoped package name
+ * in which case that is being parsed as the name, but not included as the path
+ * e.g. dir/@mono/app => ["@mono/app", "dir/app"]
+ * e.g. dir/app => ["app", "dir/app"]
+ **/
+export const parseNameAndPath = (input: string) => {
+  const paths = input.split("/");
+
+  let appName = paths[paths.length - 1]!;
+
+  // If the first part is a @, it's a scoped package
+  const indexOfDelimiter = paths.findIndex((p) => p.startsWith("@"));
+  if (paths.findIndex((p) => p.startsWith("@")) !== -1) {
+    appName = paths.slice(indexOfDelimiter).join("/");
+  }
+
+  const path = paths.filter((p) => !p.startsWith("@")).join("/");
+
+  return [appName, path] as const;
+};

--- a/src/utils/validateAppName.ts
+++ b/src/utils/validateAppName.ts
@@ -1,10 +1,30 @@
+const validationRegExp =
+  /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
 //Validate a string against allowed package.json names
 export const validateAppName = (input: string) => {
-  if (
-    /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(input)
-  ) {
+  const paths = input.split("/");
+
+  // If the first part is a @, it's a scoped package
+  const indexOfDelimiter = paths.findIndex((p) => p.startsWith("@"));
+
+  let appName = paths[paths.length - 1]!;
+  if (paths.findIndex((p) => p.startsWith("@")) !== -1) {
+    appName = paths.slice(indexOfDelimiter).join("/");
+  }
+
+  if (validationRegExp.test(appName)) {
     return true;
   } else {
     return "App name must be lowercase, alphanumeric, and only use -, _, and @";
   }
 };
+
+/**
+ * Tests:
+ *
+ * dir/app => app in dir
+ * dir/@mono/app => app in dir, but named @mono/app
+ *
+ * dir/app{} => false
+ */


### PR DESCRIPTION
Closes #72 

Not quite sure what we agreed on here, but made some changes to extend the support of the `validateAppName` feature.

## Validation
- [x] The validation is only made on the app's name and not the full path, e.g. `some/dir/to/my/app` only validates the `app` part of the path.
- [x]  The validation supports scoped packages so `my-mono/@my-mono/app` validates `@my-mono/app` as valid. `my-mono/@my-mono/apps/web` is still not valid (should it? in that case the regex has to be changed)

## Parsing the name and path from the user's input
- [x] Inputting a scoped name as part of the path now parses that correctly, i.e. `some/dir/@mono/app` scaffolds the app under `some/dir/app`, but the app's name in the package.json is `@mono/app`.

## Examples
|Input | OK? | Parsed Path | Parsed App Name|
|------|-----|-------------|----------------|
|some/path/app | Yes | some/path/app | app|
|some/path/ju[nk | No | - | - |
|some/path/mono/@mono/app | Yes | some/path/mono/app | @mono/app |

What do you think?