### PR TITLE
Text formatting and remove cursor for non link elements 

### DIFF
--- a/template/base/src/pages/index.tsx
+++ b/template/base/src/pages/index.tsx
@@ -15,7 +15,7 @@ const Home: NextPage = () => {
         </h1>
 
         <div>
-          <h3>This Stack uses:-</h3>
+          <h3>This stack uses:</h3>
           <ul>
             <li>
               <a href="https://nextjs.org" target="_blank" rel="noreferrer">

--- a/template/page-studs/index/with-auth-trpc-tw.tsx
+++ b/template/page-studs/index/with-auth-trpc-tw.tsx
@@ -39,13 +39,12 @@ const Home: NextPage = () => {
           Create <span className="text-blue-500">T3</span> App
         </h1>
 
-        <h3 className="items-center m-5 text-3xl">This Stack uses:-</h3>
+        <h3 className="items-center m-5 text-3xl">This stack uses:</h3>
 
         <main className="grid items-start grid-cols-1 gap-10 p-5 md:p-0 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-5 ">
-          
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://nextjs.org/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">NextJS</h2>
                 <p className="mb-5">The React framework for production</p>
                 <button className="p-2 px-6 w-fit self-center text-white font-bold bg-blue-500 rounded-full group-hover:bg-blue-600 duration-300">
@@ -56,8 +55,12 @@ const Home: NextPage = () => {
           </section>
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
-            <a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+            <a
+              href="https://www.typescriptlang.org/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">TypeScript</h2>
                 <p className="mb-5">
                   Strongly typed programming language that builds on JavaScript,
@@ -72,7 +75,7 @@ const Home: NextPage = () => {
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://tailwindcss.com/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">TailwindCSS</h2>
                 <p className="mb-5">
                   Rapidly build modern websites without ever leaving your HTML
@@ -86,7 +89,7 @@ const Home: NextPage = () => {
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://trpc.io/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">tRPC</h2>
                 <p className="mb-5">End-to-end typesafe APIs made easy</p>
                 <button className="p-2 px-6 w-fit self-center text-white font-bold bg-blue-500 rounded-full group-hover:bg-blue-600 duration-300">
@@ -97,8 +100,12 @@ const Home: NextPage = () => {
           </section>
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
-            <a href="https://next-auth.js.org/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+            <a
+              href="https://next-auth.js.org/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">Next-Auth</h2>
                 <p className="mb-5">Authentication for Next.js</p>
                 <button className="p-2 px-6 w-fit self-center text-white font-bold bg-blue-500 rounded-full group-hover:bg-blue-600 duration-300">
@@ -107,7 +114,6 @@ const Home: NextPage = () => {
               </div>
             </a>
           </section>
-
         </main>
       </div>
     </>

--- a/template/page-studs/index/with-auth-trpc.tsx
+++ b/template/page-studs/index/with-auth-trpc.tsx
@@ -36,7 +36,7 @@ const Home: NextPage = () => {
         </h1>
 
         <div>
-          <h3>This Stack uses:-</h3>
+          <h3>This stack uses:</h3>
           <ul>
             <li>
               <a href="https://nextjs.org" target="_blank" rel="noreferrer">

--- a/template/page-studs/index/with-trpc-tw.tsx
+++ b/template/page-studs/index/with-trpc-tw.tsx
@@ -18,13 +18,12 @@ const Home: NextPage = () => {
           Create <span className="text-blue-500">T3</span> App
         </h1>
 
-        <h3 className="items-center m-5 text-3xl">This Stack uses:-</h3>
+        <h3 className="items-center m-5 text-3xl">This stack uses:</h3>
 
         <main className="grid items-start grid-cols-1 gap-10 p-5 md:p-0 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 ">
-          
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://nextjs.org/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">NextJS</h2>
                 <p className="mb-5">The React framework for production</p>
                 <button className="p-2 px-6 w-fit self-center text-white font-bold bg-blue-500 rounded-full group-hover:bg-blue-600 duration-300">
@@ -35,8 +34,12 @@ const Home: NextPage = () => {
           </section>
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
-            <a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+            <a
+              href="https://www.typescriptlang.org/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">TypeScript</h2>
                 <p className="mb-5">
                   Strongly typed programming language that builds on JavaScript,
@@ -51,7 +54,7 @@ const Home: NextPage = () => {
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://tailwindcss.com/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">TailwindCSS</h2>
                 <p className="mb-5">
                   Rapidly build modern websites without ever leaving your HTML
@@ -65,7 +68,7 @@ const Home: NextPage = () => {
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://trpc.io/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">tRPC</h2>
                 <p className="mb-5">End-to-end typesafe APIs made easy</p>
                 <button className="p-2 px-6 w-fit self-center text-white font-bold bg-blue-500 rounded-full group-hover:bg-blue-600 duration-300">
@@ -74,7 +77,6 @@ const Home: NextPage = () => {
               </div>
             </a>
           </section>
-
         </main>
 
         <div className="py-6 text-2xl text-blue-500">

--- a/template/page-studs/index/with-trpc.tsx
+++ b/template/page-studs/index/with-trpc.tsx
@@ -21,7 +21,7 @@ const Home: NextPage = () => {
         </h1>
 
         <div>
-          <h3>This Stack uses:-</h3>
+          <h3>This stack uses:</h3>
           <ul>
             <li>
               <a href="https://nextjs.org" target="_blank" rel="noreferrer">

--- a/template/page-studs/index/with-tw.tsx
+++ b/template/page-studs/index/with-tw.tsx
@@ -15,12 +15,11 @@ const Home: NextPage = () => {
           Create <span className="text-blue-500">T3</span> App
         </h1>
 
-        <h3 className="items-center m-5 text-3xl">This Stack uses:-</h3>
+        <h3 className="items-center m-5 text-3xl">This stack uses:</h3>
         <main className="grid items-start grid-cols-1 gap-10 p-5 md:p-0 sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-          
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://nextjs.org/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">NextJS</h2>
                 <p className="mb-5">The React framework for production</p>
                 <button className="p-2 px-6 w-fit self-center text-white font-bold bg-blue-500 rounded-full group-hover:bg-blue-600 duration-300">
@@ -31,8 +30,12 @@ const Home: NextPage = () => {
           </section>
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
-            <a href="https://www.typescriptlang.org/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+            <a
+              href="https://www.typescriptlang.org/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">TypeScript</h2>
                 <p className="mb-5">
                   Strongly typed programming language that builds on JavaScript,
@@ -47,7 +50,7 @@ const Home: NextPage = () => {
 
           <section className="h-full max-h-72 transform group border-2 border-neutral-800 rounded-2xl duration-300 hover:scale-105 hover:border-blue-600 hover:-translate-y-1 hover:shadow-2xl">
             <a href="https://tailwindcss.com/" target="_blank" rel="noreferrer">
-              <div className="p-5 py-10 flex flex-col justify-center h-full cursor-pointer text-center">
+              <div className="p-5 py-10 flex flex-col justify-center h-full text-center">
                 <h2 className="mb-5 text-3xl">TailwindCSS</h2>
                 <p className="mb-5">
                   Rapidly build modern websites without ever leaving your HTML
@@ -58,7 +61,6 @@ const Home: NextPage = () => {
               </div>
             </a>
           </section>
-
         </main>
       </div>
     </>


### PR DESCRIPTION
Small update to some UX things while poking around.

1. Remove `-` char, and lowercased `stack` on heading text... `This Stack uses:-` -> `This stack uses:` within templates.
2. Removed `cursor-pointer` on `div` element. Will still have hover effect but now only the link will show as clickable.