### PR TITLE
fix: remove unncesary import on auth router

### DIFF
--- a/template/addons/trpc/auth-router.ts
+++ b/template/addons/trpc/auth-router.ts
@@ -1,6 +1,5 @@
 import { TRPCError } from "@trpc/server";
 import { createRouter } from "./context";
-import { z } from "zod";
 
 export const authRouter = createRouter()
   .query("getSession", {


### PR DESCRIPTION
We're not using Zod here