### PR TITLE
fix(cli): use correct spelling, fix short choices

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,8 +106,8 @@ export const runCli = async () => {
         type: "list",
         message: "Will you be using JavaScript or TypeScript?",
         choices: [
-          { name: "Typescript", value: "typescript", short: "Typescript" },
-          { name: "Javascript", value: "javascript", short: "Typescript" },
+          { name: "TypeScript", value: "typescript", short: "TypeScript" },
+          { name: "Javascript", value: "javascript", short: "JavaScript" },
         ],
         default: "typescript",
       });


### PR DESCRIPTION
Consistent use of the word "TypeScript" with a capital "S". This also fixes the `short` value to show "JavaScript" when that choice is selected.

See https://github.com/SBoudrias/Inquirer.js#prompt