### PR TITLE
fix: update eslint-config-next version

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -18,7 +18,7 @@
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.5",
     "eslint": "8.18.0",
-    "eslint-config-next": "12.1.6",
+    "eslint-config-next": "12.2.0",
     "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
Found an issue while adding the stable middleware. The eslint config is pointing to the wrong version.