### PR TITLE
fix: next-auth template eslint warning

### DIFF
--- a/template/addons/next-auth/restricted.ts
+++ b/template/addons/next-auth/restricted.ts
@@ -4,7 +4,10 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { unstable_getServerSession as getServerSession } from "next-auth";
 import { authOptions as nextAuthOptions } from "./auth/[...nextauth]";
 
-export default async (req: NextApiRequest, res: NextApiResponse) => {
+export default async function restrictedRouteHandler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   const session = await getServerSession(req, res, nextAuthOptions);
 
   if (session) {


### PR DESCRIPTION
Fixes ESLint warning for anonymous default export in next-auth template restricted.ts file.

![obraz](https://user-images.githubusercontent.com/24250766/177411637-ba67a390-58ef-4aa3-84cc-e1cb2bb42970.png)
