### PR TITLE
fix: incompatible git version

### DIFF
--- a/src/helpers/initGit.ts
+++ b/src/helpers/initGit.ts
@@ -10,7 +10,18 @@ export const initializeGit = async (projectDir: string) => {
   logger.info("Initializing Git...");
   const spinner = ora("Creating a new git repo...\n").start();
   try {
-    await execa("git init --initial-branch=main", { cwd: projectDir });
+    let initCmd = "git init --initial-branch=main";
+
+    // --initial-branch flag was added in git v2.28.0
+    const { stdout: gitVersionOutput } = await execa("git --version"); // git version 2.32.0 ...
+    const gitVersionTag = gitVersionOutput.split(" ")[2];
+    const major = gitVersionTag?.split(".")[0];
+    const minor = gitVersionTag?.split(".")[1];
+    if (Number(major) < 2 || Number(minor) < 28) {
+      initCmd = "git init";
+    }
+
+    await execa(initCmd, { cwd: projectDir });
     spinner.succeed(
       `${chalk.green("Successfully initialized")} ${chalk.green.bold("git")}\n`,
     );

--- a/template/base/package.json
+++ b/template/base/package.json
@@ -18,7 +18,7 @@
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.5",
     "eslint": "8.18.0",
-    "eslint-config-next": "12.1.6",
+    "eslint-config-next": "12.2.0",
     "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
Closes #96 

As discussed in above referenced issue.

The flag `initial-branch` will only be used if the version is compatible (>=2.28)

Don't know if we should switch branch to `main` by `git checkout -b main` otherwise or just leave them on `master`.