### PR TITLE
feat: add noInstall flag and prompt

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,11 +48,6 @@ export const runCli = async () => {
       "Explicitly tell the CLI to not initialize a new git repo in the project",
       false,
     )
-    // FIXME: Find a way to prevent the pkg manager from installing packages
-    // The current method of building the package.json relies on having the users package manager run multiple 'install XYZ' calls
-    // This is a good short term method to adding packages, but ultimatly it means that:
-    //  A - The user runs 'add XYZ' 2-6 times over the course of scaffolding
-    //  B - There is no way to easily add packages to the dependency array without also installing them
     .option(
       "--noInstall",
       "Explicitly tell the CLI to not run the package manager's install command",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -53,11 +53,11 @@ export const runCli = async () => {
     // This is a good short term method to adding packages, but ultimatly it means that:
     //  A - The user runs 'add XYZ' 2-6 times over the course of scaffolding
     //  B - There is no way to easily add packages to the dependency array without also installing them
-    // .option(
-    //   "--noInstall",
-    //   "Explicitly tell the CLI to not run the package manager's install command",
-    //   false,
-    // )
+    .option(
+      "--noInstall",
+      "Explicitly tell the CLI to not run the package manager's install command",
+      false,
+    )
     .option(
       "-y, --default",
       "Bypass the CLI and use all default options to bootstrap a new t3-app",
@@ -146,6 +146,28 @@ export const runCli = async () => {
       });
 
       cliResults.packages = packages;
+
+      if (!cliResults.flags.noInstall) {
+        const { runInstall } = await inquirer.prompt<{ runInstall: boolean }>({
+          name: "runInstall",
+          type: "list",
+          message: "Would you like us to run npm install?",
+          choices: [
+            { name: "Yes", value: true, short: "Yes" },
+            { name: "No", value: false, short: "No" },
+          ],
+          default: true,
+        });
+
+        if (runInstall) {
+          logger.success("Alright. We'll install the dependencies for you!");
+        } else {
+          cliResults.flags.noInstall = true;
+          logger.info(
+            "No worries. You can run 'npm install' later to install the dependencies.",
+          );
+        }
+      }
     }
   } catch (err) {
     // If the user is not calling create-t3-app from an interactive terminal, inquirer will throw an error with isTTYError = true

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -150,12 +150,8 @@ export const runCli = async () => {
       if (!cliResults.flags.noInstall) {
         const { runInstall } = await inquirer.prompt<{ runInstall: boolean }>({
           name: "runInstall",
-          type: "list",
+          type: "confirm",
           message: "Would you like us to run npm install?",
-          choices: [
-            { name: "Yes", value: true, short: "Yes" },
-            { name: "No", value: false, short: "No" },
-          ],
           default: true,
         });
 

--- a/src/helpers/createProject.ts
+++ b/src/helpers/createProject.ts
@@ -5,13 +5,17 @@ import { installPackages } from "./installPackages.js";
 import { scaffoldProject } from "./scaffoldProject.js";
 import { selectAppFile, selectIndexFile } from "./selectBoilerplate.js";
 
-export const createProject = async (opts: {
+interface CreateProjectOptions {
   projectName: string;
   packages: PkgInstallerMap;
   noInstall: boolean;
-}) => {
-  const { projectName, packages, noInstall } = opts;
+}
 
+export const createProject = async ({
+  projectName,
+  packages,
+  noInstall,
+}: CreateProjectOptions) => {
   const pkgManager = getUserPkgManager();
   const projectDir = path.resolve(process.cwd(), projectName);
 

--- a/src/helpers/createProject.ts
+++ b/src/helpers/createProject.ts
@@ -5,18 +5,21 @@ import { installPackages } from "./installPackages.js";
 import { scaffoldProject } from "./scaffoldProject.js";
 import { selectAppFile, selectIndexFile } from "./selectBoilerplate.js";
 
-export const createProject = async (
-  projectName: string,
-  packages: PkgInstallerMap,
-) => {
+export const createProject = async (opts: {
+  projectName: string;
+  packages: PkgInstallerMap;
+  noInstall: boolean;
+}) => {
+  const { projectName, packages, noInstall } = opts;
+
   const pkgManager = getUserPkgManager();
   const projectDir = path.resolve(process.cwd(), projectName);
 
   // Bootstraps the base Next.js application
-  await scaffoldProject(projectName, projectDir, pkgManager);
+  await scaffoldProject({ projectName, projectDir, pkgManager, noInstall });
 
   // Install the selected packages
-  await installPackages(projectDir, pkgManager, packages);
+  await installPackages({ projectDir, pkgManager, packages, noInstall });
 
   // TODO: Look into using handlebars or other templating engine to scaffold without needing to maintain multiple copies of the same file
   await selectAppFile(projectDir, packages);

--- a/src/helpers/installPackages.ts
+++ b/src/helpers/installPackages.ts
@@ -5,19 +5,28 @@ import ora from "ora";
 import { logger } from "../utils/logger.js";
 
 // This runs the installer for all the packages that the user has selected
-export const installPackages = async (
-  projectDir: string,
-  pkgManager: PackageManager,
-  packages: PkgInstallerMap,
-) => {
-  logger.info("Installing packages...");
+export const installPackages = async (opts: {
+  projectDir: string;
+  pkgManager: PackageManager;
+  packages: PkgInstallerMap;
+  noInstall: boolean;
+}) => {
+  const { projectDir, pkgManager, packages, noInstall } = opts;
 
-  for (const [name, opts] of Object.entries(packages)) {
-    if (opts.inUse) {
-      const spinner = ora(`Installing ${name}...`).start();
-      await opts.installer(projectDir, pkgManager, packages);
+  logger.info(`${noInstall ? "Adding" : "Installing"} packages...`);
+
+  for (const [name, pkgOpts] of Object.entries(packages)) {
+    if (pkgOpts.inUse) {
+      const spinner = ora(
+        `${noInstall ? "Adding" : "Installing"} ${name}...`,
+      ).start();
+      await pkgOpts.installer({ projectDir, pkgManager, packages, noInstall });
       spinner.succeed(
-        chalk.green(`Successfully installed ${chalk.green.bold(name)}`),
+        chalk.green(
+          `Successfully ${noInstall ? "added" : "installed"} ${chalk.green.bold(
+            name,
+          )}`,
+        ),
       );
     }
   }

--- a/src/helpers/installPackages.ts
+++ b/src/helpers/installPackages.ts
@@ -4,15 +4,20 @@ import chalk from "chalk";
 import ora from "ora";
 import { logger } from "../utils/logger.js";
 
-// This runs the installer for all the packages that the user has selected
-export const installPackages = async (opts: {
+interface InstallPackagesOptions {
   projectDir: string;
   pkgManager: PackageManager;
   packages: PkgInstallerMap;
   noInstall: boolean;
-}) => {
-  const { projectDir, pkgManager, packages, noInstall } = opts;
+}
 
+// This runs the installer for all the packages that the user has selected
+export const installPackages = async ({
+  projectDir,
+  pkgManager,
+  packages,
+  noInstall,
+}: InstallPackagesOptions) => {
   logger.info(`${noInstall ? "Adding" : "Installing"} packages...`);
 
   for (const [name, pkgOpts] of Object.entries(packages)) {

--- a/src/helpers/logNextSteps.ts
+++ b/src/helpers/logNextSteps.ts
@@ -3,14 +3,20 @@ import { getUserPkgManager } from "../utils/getUserPkgManager.js";
 import { logger } from "../utils/logger.js";
 
 // This logs the next steps that the user should take in order to advance the project
-export const logNextSteps = (
-  projectName: string,
-  packages: PkgInstallerMap,
-) => {
+export const logNextSteps = (opts: {
+  projectName: string;
+  packages: PkgInstallerMap;
+  noInstall: boolean;
+}) => {
+  const { projectName, packages, noInstall } = opts;
+
   const pkgManager = getUserPkgManager();
 
   logger.info("Next steps:");
   logger.info(`  cd ${projectName}`);
+  if (!noInstall) {
+    logger.info(`  ${pkgManager} install`);
+  }
 
   if (packages.prisma.inUse) {
     logger.info(

--- a/src/helpers/logNextSteps.ts
+++ b/src/helpers/logNextSteps.ts
@@ -2,14 +2,18 @@ import type { PkgInstallerMap } from "../installers/index.js";
 import { getUserPkgManager } from "../utils/getUserPkgManager.js";
 import { logger } from "../utils/logger.js";
 
-// This logs the next steps that the user should take in order to advance the project
-export const logNextSteps = (opts: {
+interface LogNextStepsOptions {
   projectName: string;
   packages: PkgInstallerMap;
   noInstall: boolean;
-}) => {
-  const { projectName, packages, noInstall } = opts;
+}
 
+// This logs the next steps that the user should take in order to advance the project
+export const logNextSteps = ({
+  projectName,
+  packages,
+  noInstall,
+}: LogNextStepsOptions) => {
   const pkgManager = getUserPkgManager();
 
   logger.info("Next steps:");

--- a/src/helpers/logNextSteps.ts
+++ b/src/helpers/logNextSteps.ts
@@ -14,7 +14,7 @@ export const logNextSteps = (opts: {
 
   logger.info("Next steps:");
   logger.info(`  cd ${projectName}`);
-  if (!noInstall) {
+  if (noInstall) {
     logger.info(`  ${pkgManager} install`);
   }
 

--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -9,11 +9,14 @@ import { type PackageManager } from "../utils/getUserPkgManager.js";
 import { logger } from "../utils/logger.js";
 
 // This bootstraps the base Next.js application
-export const scaffoldProject = async (
-  projectName: string,
-  projectDir: string,
-  pkgManager: PackageManager,
-) => {
+export const scaffoldProject = async (opts: {
+  projectName: string;
+  projectDir: string;
+  pkgManager: PackageManager;
+  noInstall: boolean;
+}) => {
+  const { projectName, projectDir, pkgManager, noInstall } = opts;
+
   const srcDir = path.join(PKG_ROOT, "template/base");
 
   logger.info(`\nUsing: ${chalk.cyan.bold(pkgManager)}\n`);
@@ -52,7 +55,8 @@ export const scaffoldProject = async (
 
   await fs.copy(srcDir, projectDir);
 
-  await execa(`${pkgManager} install`, { cwd: projectDir });
-
+  if (!noInstall) {
+    await execa(`${pkgManager} install`, { cwd: projectDir });
+  }
   spinner.succeed(`${chalk.cyan.bold(projectName)} scaffolded successfully!\n`);
 };

--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -21,6 +21,8 @@ export const scaffoldProject = async (opts: {
 
   if (!noInstall) {
     logger.info(`\nUsing: ${chalk.cyan.bold(pkgManager)}\n`);
+  } else {
+    logger.info("");
   }
 
   const spinner = ora(`Scaffolding in: ${projectDir}...\n`).start();

--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -19,7 +19,10 @@ export const scaffoldProject = async (opts: {
 
   const srcDir = path.join(PKG_ROOT, "template/base");
 
-  logger.info(`\nUsing: ${chalk.cyan.bold(pkgManager)}\n`);
+  if (!noInstall) {
+    logger.info(`\nUsing: ${chalk.cyan.bold(pkgManager)}\n`);
+  }
+
   const spinner = ora(`Scaffolding in: ${projectDir}...\n`).start();
 
   if (fs.existsSync(projectDir)) {

--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -8,15 +8,20 @@ import { execa } from "../utils/execAsync.js";
 import { type PackageManager } from "../utils/getUserPkgManager.js";
 import { logger } from "../utils/logger.js";
 
-// This bootstraps the base Next.js application
-export const scaffoldProject = async (opts: {
+interface ScaffoldProjectOptions {
   projectName: string;
   projectDir: string;
   pkgManager: PackageManager;
   noInstall: boolean;
-}) => {
-  const { projectName, projectDir, pkgManager, noInstall } = opts;
+}
 
+// This bootstraps the base Next.js application
+export const scaffoldProject = async ({
+  projectName,
+  projectDir,
+  pkgManager,
+  noInstall,
+}: ScaffoldProjectOptions) => {
   const srcDir = path.join(PKG_ROOT, "template/base");
 
   if (!noInstall) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,19 +16,22 @@ const main = async () => {
   const {
     appName,
     packages,
-    flags: { noGit },
+    flags: { noGit, noInstall },
   } = await runCli();
 
   const usePackages = buildPkgInstallerMap(packages);
 
-  const projectDir = await createProject(appName, usePackages);
+  const projectDir = await createProject({
+    projectName: appName,
+    packages: usePackages,
+    noInstall,
+  });
 
   if (!noGit) {
     await initializeGit(projectDir);
   }
 
-  logNextSteps(appName, usePackages);
-
+  logNextSteps({ projectName: appName, packages: usePackages, noInstall });
   const pkgJson = (await fs.readJSON(
     path.join(projectDir, "package.json"),
   )) as PackageJson;

--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -15,12 +15,14 @@ export const availablePackages = [
 
 export type AvailablePackages = typeof availablePackages[number];
 
-export type Installer = (opts: {
+export interface CommonOptions {
   projectDir: string;
   pkgManager: PackageManager;
   packages: PkgInstallerMap;
   noInstall: boolean;
-}) => Promise<void>;
+}
+
+export type Installer = (opts: CommonOptions) => Promise<void>;
 
 export type PkgInstallerMap = {
   [pkg in AvailablePackages]: {

--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -15,11 +15,12 @@ export const availablePackages = [
 
 export type AvailablePackages = typeof availablePackages[number];
 
-export type Installer = (
-  projectDir: string,
-  packageManager: PackageManager,
-  packages: PkgInstallerMap,
-) => Promise<void>;
+export type Installer = (opts: {
+  projectDir: string;
+  pkgManager: PackageManager;
+  packages: PkgInstallerMap;
+  noInstall: boolean;
+}) => Promise<void>;
 
 export type PkgInstallerMap = {
   [pkg in AvailablePackages]: {

--- a/src/installers/next-auth.ts
+++ b/src/installers/next-auth.ts
@@ -4,19 +4,21 @@ import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
 import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
-export const nextAuthInstaller: Installer = async (
+export const nextAuthInstaller: Installer = async ({
+  pkgManager,
   projectDir,
-  packageManager,
   packages,
-) => {
+  noInstall,
+}) => {
   await runPkgManagerInstall({
-    packageManager,
+    pkgManager,
     projectDir,
     packages: [
       "next-auth",
       packages.prisma.inUse ? "@next-auth/prisma-adapter" : "",
     ],
     devMode: false,
+    noInstallMode: noInstall,
   });
 
   const nextAuthAssetDir = path.join(PKG_ROOT, "template/addons/next-auth");

--- a/src/installers/prisma.ts
+++ b/src/installers/prisma.ts
@@ -6,22 +6,25 @@ import { PKG_ROOT } from "../consts.js";
 import { execa } from "../utils/execAsync.js";
 import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
-export const prismaInstaller: Installer = async (
+export const prismaInstaller: Installer = async ({
   projectDir,
-  packageManager,
+  pkgManager,
   packages,
-) => {
+  noInstall,
+}) => {
   await runPkgManagerInstall({
-    packageManager,
+    pkgManager,
     projectDir,
     packages: ["prisma"],
     devMode: true,
+    noInstallMode: noInstall,
   });
   await runPkgManagerInstall({
-    packageManager,
+    pkgManager,
     projectDir,
     packages: ["@prisma/client"],
     devMode: false,
+    noInstallMode: noInstall,
   });
 
   const prismaAssetDir = path.join(PKG_ROOT, "template/addons/prisma");
@@ -53,9 +56,12 @@ export const prismaInstaller: Installer = async (
     }),
   ]);
 
-  const generateClientCmd =
-    packageManager === "npm"
-      ? "npx prisma generate"
-      : `${packageManager} prisma generate`;
-  await execa(generateClientCmd, { cwd: projectDir });
+  // only generate client if we have installed the dependencies
+  if (!noInstall) {
+    const generateClientCmd =
+      pkgManager === "npm"
+        ? "npx prisma generate"
+        : `${pkgManager} prisma generate`;
+    await execa(generateClientCmd, { cwd: projectDir });
+  }
 };

--- a/src/installers/tailwind.ts
+++ b/src/installers/tailwind.ts
@@ -4,15 +4,17 @@ import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
 import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
-export const tailwindInstaller: Installer = async (
+export const tailwindInstaller: Installer = async ({
   projectDir,
-  packageManager,
-) => {
+  pkgManager,
+  noInstall,
+}) => {
   await runPkgManagerInstall({
-    packageManager,
+    pkgManager,
     projectDir,
     packages: ["tailwindcss", "postcss", "autoprefixer"],
     devMode: true,
+    noInstallMode: noInstall,
   });
 
   const twAssetDir = path.join(PKG_ROOT, "template/addons/tailwind");

--- a/src/installers/trpc.ts
+++ b/src/installers/trpc.ts
@@ -4,13 +4,14 @@ import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
 import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
-export const trpcInstaller: Installer = async (
+export const trpcInstaller: Installer = async ({
   projectDir,
-  packageManager,
+  pkgManager,
   packages,
-) => {
+  noInstall,
+}) => {
   await runPkgManagerInstall({
-    packageManager,
+    pkgManager,
     projectDir,
     packages: [
       "react-query",
@@ -22,6 +23,7 @@ export const trpcInstaller: Installer = async (
       "zod",
     ],
     devMode: false,
+    noInstallMode: noInstall,
   });
   const usingAuth = packages.nextAuth.inUse;
   const usingPrisma = packages.prisma.inUse;

--- a/src/utils/runPkgManagerInstall.ts
+++ b/src/utils/runPkgManagerInstall.ts
@@ -21,6 +21,7 @@ export const runPkgManagerInstall = async (opts: {
 
     for (const pkg of packages) {
       if (pkg === "") {
+        // sometimes empty string is passed as a package when using ternaries so escaping that to prevent it pulling node's version
         continue;
       }
       const { stdout: latestVersion } = await execa(`npm show ${pkg} version`);

--- a/src/utils/runPkgManagerInstall.ts
+++ b/src/utils/runPkgManagerInstall.ts
@@ -1,18 +1,51 @@
 import type { PackageManager } from "./getUserPkgManager.js";
+import path from "path";
+import fs from "fs-extra";
+import { type PackageJson } from "type-fest";
 import { execa } from "./execAsync.js";
+import { logger } from "./logger.js";
 
 export const runPkgManagerInstall = async (opts: {
-  packageManager: PackageManager;
+  pkgManager: PackageManager;
   devMode: boolean;
   projectDir: string;
   packages: string[];
+  noInstallMode: boolean;
 }) => {
-  const { packageManager, devMode, projectDir, packages } = opts;
+  const { pkgManager, devMode, projectDir, packages, noInstallMode } = opts;
+
+  if (noInstallMode) {
+    const pkgJson = (await fs.readJSON(
+      path.join(projectDir, "package.json"),
+    )) as PackageJson;
+
+    for (const pkg of packages) {
+      if (pkg === "") {
+        continue;
+      }
+      const { stdout: latestVersion } = await execa(`npm show ${pkg} version`);
+      logger.info("Resolved latest version of", pkg, "to", latestVersion);
+      if (!latestVersion) {
+        logger.warn("WARN: Failed to resolve latest version of package:", pkg);
+        continue;
+      }
+
+      // Note: We know that pkgJson.[dev]Dependencies exists in the base Next.js template so we don't need to validate it
+      if (devMode) {
+        pkgJson.devDependencies![pkg] = `^${latestVersion.trim()}`; //eslint-disable-line @typescript-eslint/no-non-null-assertion
+      } else {
+        pkgJson.dependencies![pkg] = `^${latestVersion.trim()}`; //eslint-disable-line @typescript-eslint/no-non-null-assertion
+      }
+    }
+
+    await fs.writeJSON(path.join(projectDir, "package.json"), pkgJson, {
+      spaces: 2,
+    });
+    return;
+  }
 
   const installCmd =
-    packageManager === "yarn"
-      ? `${packageManager} add`
-      : `${packageManager} install`;
+    pkgManager === "yarn" ? `${pkgManager} add` : `${pkgManager} install`;
   const flag = devMode ? "-D" : "";
   const fullCmd = `${installCmd} ${flag} ${packages.join(" ")}`;
   await execa(fullCmd, { cwd: projectDir });

--- a/src/utils/runPkgManagerInstall.ts
+++ b/src/utils/runPkgManagerInstall.ts
@@ -24,7 +24,6 @@ export const runPkgManagerInstall = async (opts: {
         continue;
       }
       const { stdout: latestVersion } = await execa(`npm show ${pkg} version`);
-      logger.info("Resolved latest version of", pkg, "to", latestVersion);
       if (!latestVersion) {
         logger.warn("WARN: Failed to resolve latest version of package:", pkg);
         continue;


### PR DESCRIPTION
Has been discussed previously (#37, #58, #128 etc.).

Enables the `--noInstall` CLI flag and adds a prompt for it. This skips the installation process and only adds the dependency to the `package.json` and copies over the boilerplate.

I ended up using `npm show <pkg> version` for this, so for tRPC it's still kinda slow (see snippet below) since there are a lot of dependencies whose versions needs to be fetched. An alternative is to keep a config-file with all the latest versions and update that from time to time. 

There are probably also some awaits we could remove to optimize and do some more stuff async to speed up the process if we care about the time it takes to scaffold. I timed 36s to scaffold a full app with install and 18s (half) without installs.

Will document and clarify with some comments tomorrow.

![CleanShot 2022-07-07 at 01 30 00](https://user-images.githubusercontent.com/51714798/177660403-3ff8dfa4-f602-4452-8cd8-ba43b770448b.gif)
