### PR TITLE
fix: language prompt short answer should both be ts

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -114,7 +114,7 @@ export const runCli = async () => {
         message: "Will you be using JavaScript or TypeScript?",
         choices: [
           { name: "TypeScript", value: "typescript", short: "TypeScript" },
-          { name: "JavaScript", value: "javascript", short: "JavaScript" },
+          { name: "JavaScript", value: "javascript", short: "TypeScript" }, // Both options should have 'TypeScript' as the short value to improve UX and reduce confusion
         ],
         default: "typescript",
       });


### PR DESCRIPTION
# Language prompt short answer should both be TS

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

In a previous pr (#107) the short answer was changed to JavaScript. Both options should have a short options of TypeScript. The short value is shown after the question has been answered and we move on to the next question. 

If we are telling the user that we are going to use TS instead, but show them JS was the selected answer, it can cause confusion. Let's keep messaging consistent, enhance UX, and show them that TS is the only way forward, no matter their selection.