### PR TITLE
chore: remove extra packages no longer needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
-    "@swc/core": "^1.2.206",
     "@types/figlet": "^1.5.4",
     "@types/fs-extra": "^9.0.13",
     "@types/gradient-string": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.4
 specifiers:
   '@commitlint/cli': ^17.0.3
   '@commitlint/config-conventional': ^17.0.3
-  '@swc/core': ^1.2.206
   '@types/figlet': ^1.5.4
   '@types/fs-extra': ^9.0.13
   '@types/gradient-string': ^1.1.2
@@ -40,9 +39,8 @@ dependencies:
   ora: 6.1.1
 
 devDependencies:
-  '@commitlint/cli': 17.0.3_@swc+core@1.2.206
+  '@commitlint/cli': 17.0.3
   '@commitlint/config-conventional': 17.0.3
-  '@swc/core': 1.2.206
   '@types/figlet': 1.5.4
   '@types/fs-extra': 9.0.13
   '@types/gradient-string': 1.1.2
@@ -58,7 +56,7 @@ devDependencies:
   lint-staged: 13.0.3
   prettier: 2.7.1
   standard-version: 9.5.0
-  tsup: 6.1.2_6x5rx6tljldea3aj2btu4bowly
+  tsup: 6.1.2_typescript@4.7.4
   type-fest: 2.14.0
   typescript: 4.7.4
 
@@ -85,14 +83,14 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@commitlint/cli/17.0.3_@swc+core@1.2.206:
+  /@commitlint/cli/17.0.3:
     resolution: {integrity: sha512-oAo2vi5d8QZnAbtU5+0cR2j+A7PO8zuccux65R/EycwvsZrDVyW518FFrnJK2UQxbRtHFFIG+NjQ6vOiJV0Q8A==}
     engines: {node: '>=v14'}
     hasBin: true
     dependencies:
       '@commitlint/format': 17.0.0
       '@commitlint/lint': 17.0.3
-      '@commitlint/load': 17.0.3_@swc+core@1.2.206
+      '@commitlint/load': 17.0.3
       '@commitlint/read': 17.0.0
       '@commitlint/types': 17.0.0
       execa: 5.1.1
@@ -159,7 +157,7 @@ packages:
       '@commitlint/types': 17.0.0
     dev: true
 
-  /@commitlint/load/17.0.3_@swc+core@1.2.206:
+  /@commitlint/load/17.0.3:
     resolution: {integrity: sha512-3Dhvr7GcKbKa/ey4QJ5MZH3+J7QFlARohUow6hftQyNjzoXXROm+RwpBes4dDFrXG1xDw9QPXA7uzrOShCd4bw==}
     engines: {node: '>=v14'}
     dependencies:
@@ -170,7 +168,7 @@ packages:
       '@types/node': 18.0.0
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 2.0.2_u6255fo3dtyusn66qpg5mepp34
+      cosmiconfig-typescript-loader: 2.0.2_qiyc72axg2v44xl4yovan2v55u
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.7.4
@@ -336,143 +334,6 @@ packages:
       picocolors: 1.0.0
       tiny-glob: 0.2.9
       tslib: 2.4.0
-    dev: true
-
-  /@swc/core-android-arm-eabi/1.2.206:
-    resolution: {integrity: sha512-lizhy9LIRxOYjF/FShzS5NIWmCSjH4JRmcUGwemhGh/TZbepzSuss4X8VoOZ6qhuI2K2vQUtyMYFxJufNxLAvQ==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-android-arm64/1.2.206:
-    resolution: {integrity: sha512-MfYVgLTtwc33G+4l7TYM6kk3OBZAKApdDvAkusx1KXDQGgENhwEGUwYtM76ZqQT6AZMXm2RtbWYxYeJ3xE6dJQ==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-darwin-arm64/1.2.206:
-    resolution: {integrity: sha512-Cp0b2l37nKiqfrxAZeyPIE3s09Xmhid8FeobKhEaG+RJVjGPQo4nlWNFlcPYxA568UQSy6kzRfAns+GkZTL7OQ==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-darwin-x64/1.2.206:
-    resolution: {integrity: sha512-8j9S+cCrmCAQ37qgDmLC6RPMR0XrrgC7c/TrRPaXmXKzfJja3TSM3EY+s6pk0Lv6izQNpSnu1g/fpItOXvw4Qg==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-freebsd-x64/1.2.206:
-    resolution: {integrity: sha512-iqGn6hZVkMeD6a+at75Cfozu8YuErPrI0p26CJRUfGfvHay5hM64jPYg8AGAvz5M/EaytN1b+vbHbIzDzSarUQ==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-linux-arm-gnueabihf/1.2.206:
-    resolution: {integrity: sha512-Z4c3SbnbN3dtN960+c7mm8QHIaorRX9cIDI7IOHw42VyqgYky5AcuZnOQrM6XKdflulPAd8siJaUh1SMSRxiiA==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-linux-arm64-gnu/1.2.206:
-    resolution: {integrity: sha512-CwNJv9yBhRFgG4YPrXSMf6wCLp3dHjARuQI+IV6ep0at7DyxpmNKIMkmo2Ru8fhMCKfxILdOezn+PCfH5SkCqg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-linux-arm64-musl/1.2.206:
-    resolution: {integrity: sha512-HyndSMfsuNZ9oZf4vVRmTJ6VXLbG3WLV2uzqnYo6ezjpcHqBI8VlgW5qSxlTa1Gxisw6ye9YX5M+NddX/jGlMQ==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-linux-x64-gnu/1.2.206:
-    resolution: {integrity: sha512-eGzXsW1u65RmsrqRHfpYsYBOPZCuYf0aVXCsXYmQMJ0CuK1hIWyvA5LMOqFZNQJS3+Np5ezZ5OiH2KaxzCtWRA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-linux-x64-musl/1.2.206:
-    resolution: {integrity: sha512-WXuAaee7PNOllQjMm/IaqrJeYG3x0B32LtbdMDh++fe53zMytrilHmmE+IfxzZFBa4Hacu7U1JyTG+cFBpmscA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-win32-arm64-msvc/1.2.206:
-    resolution: {integrity: sha512-IqXVI4WAYlX2V8rXZrUEz3qljm3n5EA43zVSG4SlwnE3nbgzvlX5Yw1U06n2/Z7Q/n5mYV3XOik6LIJ5G5MiFw==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-win32-ia32-msvc/1.2.206:
-    resolution: {integrity: sha512-wO8+BpfEEX4dGZPoLft7SoGeMf3NbUvuSkjzkFl0y81YCRTt+UQngSyNI3irIrAoh5u3lE3g9Pt4GX4gIYxT+Q==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core-win32-x64-msvc/1.2.206:
-    resolution: {integrity: sha512-LTC1x4VeWnHBtCKw7CLk3fbp3FxgcrjkbM2gS32qOCVl6QNVw+GoyWtnEEb9biAO/MjK/AESz96ew4cgmBVAJw==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@swc/core/1.2.206:
-    resolution: {integrity: sha512-+n+WgDHW7vxT4Ja1kExCbHa6Wt3Ub3xztVcXsjB74O4/j0Z2j955/+zHEnYVTxIzlksI1wn2WAhT2mPJeMZ1Fg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    optionalDependencies:
-      '@swc/core-android-arm-eabi': 1.2.206
-      '@swc/core-android-arm64': 1.2.206
-      '@swc/core-darwin-arm64': 1.2.206
-      '@swc/core-darwin-x64': 1.2.206
-      '@swc/core-freebsd-x64': 1.2.206
-      '@swc/core-linux-arm-gnueabihf': 1.2.206
-      '@swc/core-linux-arm64-gnu': 1.2.206
-      '@swc/core-linux-arm64-musl': 1.2.206
-      '@swc/core-linux-x64-gnu': 1.2.206
-      '@swc/core-linux-x64-musl': 1.2.206
-      '@swc/core-win32-arm64-msvc': 1.2.206
-      '@swc/core-win32-ia32-msvc': 1.2.206
-      '@swc/core-win32-x64-msvc': 1.2.206
     dev: true
 
   /@tsconfig/node10/1.0.9:
@@ -1246,7 +1107,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader/2.0.2_u6255fo3dtyusn66qpg5mepp34:
+  /cosmiconfig-typescript-loader/2.0.2_qiyc72axg2v44xl4yovan2v55u:
     resolution: {integrity: sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -1255,7 +1116,7 @@ packages:
     dependencies:
       '@types/node': 18.0.0
       cosmiconfig: 7.0.1
-      ts-node: 10.8.2_u6255fo3dtyusn66qpg5mepp34
+      ts-node: 10.8.2_qiyc72axg2v44xl4yovan2v55u
       typescript: 4.7.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -3839,7 +3700,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node/10.8.2_u6255fo3dtyusn66qpg5mepp34:
+  /ts-node/10.8.2_qiyc72axg2v44xl4yovan2v55u:
     resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}
     hasBin: true
     peerDependencies:
@@ -3854,7 +3715,6 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.2.206
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -3887,7 +3747,7 @@ packages:
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
-  /tsup/6.1.2_6x5rx6tljldea3aj2btu4bowly:
+  /tsup/6.1.2_typescript@4.7.4:
     resolution: {integrity: sha512-Hw4hKDHaAQkm2eVavlArEOrAPA93bziRDamdfwaNs0vXQdUUFfItvUWY0L/F6oQQMVh6GvjQq1+HpDXw8UKtPA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -3903,7 +3763,6 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@swc/core': 1.2.206
       bundle-require: 3.0.4_esbuild@0.14.47
       cac: 6.7.12
       chokidar: 3.5.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,8 +38,8 @@
     /* OTHER OPTIONS */
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
+    // "emitDecoratorMetadata": true,
+    // "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true


### PR DESCRIPTION
# remove extra packages no longer needed

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

- update tsconfig to turn off emit decorator metadata flag as we aren't using any
- remove @swc/core from dev dependencies as it was only added to silence tsup emitDecorator warnings

---