### PR TITLE
docs: fix link to init.tips/others in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ It consists of
 - [Prisma](https://prisma.io)
 - [NextAuth.js](https://next-auth.js.org)
 
-If you're looking for more info about this stack (state management solutions, deployment recommendations, etc) - check out [init.tips](https://init.tips/other)
+If you're looking for more info about this stack (state management solutions, deployment recommendations, etc) - check out [init.tips](https://init.tips/others)
 
 </div>
 


### PR DESCRIPTION
# Fix link to [init.tips/others](https://init.tips/others) in README

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

💯