### PR TITLE
chore: bump nextjs version to 12.2.1

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "12.2.0",
+    "next": "12.2.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
@@ -18,7 +18,7 @@
     "@types/react": "18.0.14",
     "@types/react-dom": "18.0.5",
     "eslint": "8.18.0",
-    "eslint-config-next": "12.2.0",
+    "eslint-config-next": "12.2.1",
     "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
# Bump nextjs version

- [x] I reviewed linter warnings + errors, resolved formatting, types, and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Bump next.js version to [12.2.1](https://github.com/vercel/next.js/releases/tag/v12.2.1)

---

## Screenshots
<img width="603" alt="image" src="https://user-images.githubusercontent.com/10283686/178070453-98e53da9-2f91-40b1-9102-b251f8c73ada.png">

<img width="307" alt="image" src="https://user-images.githubusercontent.com/10283686/178070400-3c5d2044-5158-4553-b3ab-57d380edb303.png">

💯
