### PR TITLE
fix: Typo in restricted endpoint error

### DIFF
--- a/template/addons/next-auth/restricted.ts
+++ b/template/addons/next-auth/restricted.ts
@@ -14,7 +14,8 @@ const restricted = async (req: NextApiRequest, res: NextApiResponse) => {
     });
   } else {
     res.send({
-      error: "You must be sign in to view the protected content on this page.",
+      error:
+        "You must be signed in to view the protected content on this page.",
     });
   }
 };


### PR DESCRIPTION
# Typo in restricted endpoint error message

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Found a minor typo and formatting error in the message returned from the `restricted.ts` endpoint when unauthorized.

---

## Screenshots

<img width="877" alt="Screenshot of restricted endpoint error message" src="https://user-images.githubusercontent.com/12433465/178095003-481f64ec-0887-460b-8da5-3de445a9d7a4.png">

💯