### PR TITLE
fix: replaced process with typeof window since it's deprecated

### DIFF
--- a/template/page-studs/_app/with-trpc.tsx
+++ b/template/page-studs/_app/with-trpc.tsx
@@ -13,7 +13,7 @@ const getBaseUrl = () => {
   if (typeof window !== "undefined") {
     return "";
   }
-  if (process.browser) return ""; // Browser should use current path
+  if (typeof window !== "undefined") return ""; // Browser should use current path
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // SSR should use vercel url
 
   return `http://localhost:${process.env.PORT ?? 3000}`; // dev SSR should use localhost


### PR DESCRIPTION
# replaced process.browser with typeof window

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---
replaced process.browser with typeof window since it's depreciated refer to this [comment](https://github.com/vercel/next.js/issues/5354#issuecomment-520305040)

---
💯
