### PR TITLE
fix: properly display the welcome title when installing with Yarn

### DIFF
--- a/src/utils/renderTitle.ts
+++ b/src/utils/renderTitle.ts
@@ -15,5 +15,5 @@ const poimandresTheme = {
 export const renderTitle = () => {
   const text = figlet.textSync(TITLE_TEXT, { font: "Small" });
   const t3Gradient = gradient(Object.values(poimandresTheme));
-  console.log(t3Gradient.multiline(text));
+  console.log("\n", t3Gradient.multiline(text));
 };


### PR DESCRIPTION
# [Short title]

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

When installing the CLI using Yarn, the welcome is not correctly printed (as you can see in the screenshot below).

---

## Screenshots

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/15611134/178116391-ebe66534-117b-4b75-ac19-3721c14f6385.png">

💯
