### PR TITLE
refactor: interface converted to type

### DIFF
--- a/src/helpers/installPackages.ts
+++ b/src/helpers/installPackages.ts
@@ -3,9 +3,9 @@ import chalk from "chalk";
 import ora from "ora";
 import { logger } from "../utils/logger.js";
 
-interface InstallPackagesOptions extends InstallerOptions {
+type InstallPackagesOptions = {
   packages: PkgInstallerMap;
-}
+} & InstallerOptions;
 // This runs the installer for all the packages that the user has selected
 export const installPackages = async ({
   projectDir,
@@ -14,7 +14,7 @@ export const installPackages = async ({
   noInstall,
 }: InstallPackagesOptions) => {
   logger.info(`${noInstall ? "Adding" : "Installing"} packages...`);
-
+  if (!packages) return;
   for (const [name, pkgOpts] of Object.entries(packages)) {
     if (pkgOpts.inUse) {
       const spinner = ora(


### PR DESCRIPTION
# Opaque type intersection over interface

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Converted the interface to a type keeping the opaque types previously used,
this allows for the types to be inferred correctly passed into the `installer()` and
reveals that the `packages`  argument was potentially `undefined` and never handled.

---

## Screenshots

![image](https://user-images.githubusercontent.com/27247160/178125030-12deb001-e24e-4c26-95fc-9047c5be3c94.png)

💯
