### PR TITLE
chore: remove unnecessary type guard

### DIFF
--- a/src/helpers/installPackages.ts
+++ b/src/helpers/installPackages.ts
@@ -14,7 +14,7 @@ export const installPackages = async ({
   noInstall,
 }: InstallPackagesOptions) => {
   logger.info(`${noInstall ? "Adding" : "Installing"} packages...`);
-  if (!packages) return;
+
   for (const [name, pkgOpts] of Object.entries(packages)) {
     if (pkgOpts.inUse) {
       const spinner = ora(


### PR DESCRIPTION
Removed the type guard checking for packages to be undefined, which should never be the case in this function.

# [Short title]

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

