### PR TITLE
fix: linting in base and directory

### DIFF
--- a/template/base/package.json
+++ b/template/base/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint --dir src"
   },
   "dependencies": {
     "next": "12.2.1",

--- a/template/base/src/pages/_app.tsx
+++ b/template/base/src/pages/_app.tsx
@@ -1,5 +1,5 @@
-import "../styles/globals.css";
 import type { AppType } from "next/dist/shared/lib/utils";
+import "../styles/globals.css";
 
 const MyApp: AppType = ({ Component, pageProps }) => {
   return <Component {...pageProps} />;


### PR DESCRIPTION
# Fix linting in base setup and linting being exclusive to /pages directory

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Fixes two issues I noticed on a base install:
1. Base install fails lint:
```bash
% yarn start
yarn run v1.22.18
$ node dist/index.js

    ___ ___ ___   _ _____ ___   _____ ____    _   ___ ___ 
  / __| _ \ __| /_\_   _| __| |_   _|__ /   /_\ | _ \ _ \
 | (__|   / _| / _ \| | | _|    | |  |_ \  / _ \|  _/  _/
  \___|_|_\___/_/ \_\_| |___|   |_| |___/ /_/ \_\_| |_|  
                                                         
? What will your project be called? test
? Will you be using JavaScript or TypeScript? TypeScript
Good choice! Using TypeScript!
? Which packages would you like to enable? 
? Initialize a new git repository? Yes
Nice one! Initializing repository!
? Would you like us to run yarn install? Yes
Alright. We'll install the dependencies for you!

Using: yarn

✔ test scaffolded successfully!

Installing packages...

Initializing Git...
✔ Successfully initialized git

Next steps:
  cd test
  yarn dev
✨  Done in 23.95s.
% cd test 
% yarn lint
yarn run v1.22.18
$ next lint

./src/pages/_app.tsx
2:1  Error: `next/dist/shared/lib/utils` import should occur before import of `../styles/globals.css`  import/order

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
Fix was to reverse the order of the import in `_app.tsx`

2. `next lint` seems to only lint the `src/pages` directory by default
```bash
% mkdir src/server && echo 'export let test = ""' >> src/server/index.ts
% yarn lint
yarn run v1.22.18
$ next lint
✔ No ESLint warnings or errors
✨  Done in 2.57s.
% yarn lint --file src/server/index.ts 
yarn run v1.22.18
$ next lint --file src/server/index.ts

./src/server/index.ts
1:12  Error: 'test' is never reassigned. Use 'const' instead.  prefer-const

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
Fix was to add `--dir src` in the `package.json`'s lint script so the entire `src` directory is linted.

---

## Screenshots

![Screen Shot 2022-07-09 at 10 37 30 PM](https://user-images.githubusercontent.com/5711536/178129031-43178067-c000-4ac8-8c34-311a98824742.png)
![Screen Shot 2022-07-09 at 10 37 38 PM](https://user-images.githubusercontent.com/5711536/178129032-676fff3d-503e-486c-a4dd-da4e390dce38.png)


💯
