### PR TITLE
feat: add check for yarn 3

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,5 @@
+packageExtensions:
+  chalk@5.0.1:
+    dependencies:
+      "#ansi-styles": npm:ansi-styles@6.1.0
+      "#supports-color": npm:supports-color@9.2.2

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -72,6 +72,13 @@ export const runCli = async () => {
     )
     .parse(process.argv);
 
+  // FIXME: TEMPORARY WARNING WHEN USING YARN 3. SEE ISSUE #57
+  if (process.env.npm_config_user_agent?.startsWith("yarn/3")) {
+    logger.warn(`  WARNING: It looks like you are using Yarn 3. This is currently not supported,
+  and likely to result in a crash. Please run create-t3-app with another
+  package manager such as PNPM (recommended), NPM, or Yarn Classic.`);
+  }
+
   // FIXME: TEMPORARY WARNING WHEN USING NODE 18. SEE ISSUE #59
   if (process.versions.node.startsWith("18")) {
     logger.warn(`  WARNING: You are using Node.js version 18. This is currently not compatible with Next-Auth.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -76,7 +76,8 @@ export const runCli = async () => {
   if (process.env.npm_config_user_agent?.startsWith("yarn/3")) {
     logger.warn(`  WARNING: It looks like you are using Yarn 3. This is currently not supported,
   and likely to result in a crash. Please run create-t3-app with another
-  package manager such as PNPM (recommended), NPM, or Yarn Classic.`);
+  package manager such as pnpm, npm, or Yarn Classic.
+  See: https://github.com/t3-oss/create-t3-app/issues/57`);
   }
 
   // FIXME: TEMPORARY WARNING WHEN USING NODE 18. SEE ISSUE #59


### PR DESCRIPTION
# Add check for Yarn 3

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

This commit adds a warning when the CLI is run using Yarn 3. This is to alert the users of possible crashes as seen in https://github.com/t3-oss/create-t3-app/issues/57.

I followed the format of https://github.com/t3-oss/create-t3-app/pull/68 as it is a similar issue.

The `.yarnrc.yml` file is necessary so that the CLI doesn't crash before we can even check whether the user is on yarn 3. See https://github.com/chalk/chalk/issues/531.

---

## Screenshots

(screenshot has a typo in it. i fixed it, but didn't want to create another screenshot as I had already uninstalled yarn 3. Hope that's ok)

![Screenshot](https://user-images.githubusercontent.com/8353666/178258607-18c5ccd5-cf9d-4af2-b40b-d459643d25e7.png)
