### PR TITLE
fix: remove process.browser check because its deprecated

### DIFF
--- a/template/page-studs/_app/with-auth-trpc.tsx
+++ b/template/page-studs/_app/with-auth-trpc.tsx
@@ -21,7 +21,6 @@ const getBaseUrl = () => {
   if (typeof window !== "undefined") {
     return "";
   }
-  if (process.browser) return ""; // Browser should use current path
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // SSR should use vercel url
 
   return `http://localhost:${process.env.PORT ?? 3000}`; // dev SSR should use localhost


### PR DESCRIPTION
# Remove deprecated check

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Reference: https://github.com/vercel/next.js/issues/5354#issuecomment-520305040

---
