### PR TITLE
fix: conditionally run envVars installer

### DIFF
--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -54,7 +54,7 @@ export const buildPkgInstallerMap = (
     installer: trpcInstaller,
   },
   envVaribles: {
-    inUse: packages.includes("prisma") || packages.includes("nextAuth"),
+    inUse: packages.includes("prisma") || packages.includes("nextAuth"),
     installer: envVariblesInstaller,
   },
 });

--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -54,7 +54,7 @@ export const buildPkgInstallerMap = (
     installer: trpcInstaller,
   },
   envVaribles: {
-    inUse: true,
+    inUse: packages.includes("prisma") || packages.includes("nextAuth"),
     installer: envVariblesInstaller,
   },
 });


### PR DESCRIPTION
# Only run the env-installer if choosing prisma or next-auth

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

When you dont install either prisma or next-auth, there is no need to have environment variables, so we don't need to install the boilerplate for the type-safe env-vars in this case.

---

