### PR TITLE
fix: Increase size of columns for tokens

### DIFF
--- a/template/addons/prisma/auth-schema.prisma
+++ b/template/addons/prisma/auth-schema.prisma
@@ -22,12 +22,12 @@ model Account {
     type              String
     provider          String
     providerAccountId String
-    refresh_token     String?
-    access_token      String?
+    refresh_token     String? @db.Text
+    access_token      String? @db.Text
     expires_at        Int?
     token_type        String?
     scope             String?
-    id_token          String?
+    id_token          String? @db.Text
     session_state     String?
     user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
Bumped into this when trying to use google provider and getting `provided value for the column is too long for the column's type`. Noticed this was missing from the schema on the next-auth [docs](https://next-auth.js.org/adapters/prisma)