### PR TITLE
feat: add db.sqlite to gitignore

### DIFF
--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # database
-db.sqlite
+/prisma/db.sqlite
 
 # next.js
 /.next/

--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -8,6 +8,9 @@
 # testing
 /coverage
 
+# database
+db.sqlite
+
 # next.js
 /.next/
 /out/


### PR DESCRIPTION
# Add db.sqlite to gitignore

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

_[Short summary/description of story/feature/bugfix]_

As mentioned in https://github.com/t3-oss/create-t3-app/issues/200, the `db.sqlite` file created by the default prisma config was not included in .gitignore. 

I believe it's better to include it - Because we're not automatically creating a 'project initialized commit', it's easy to overlook the db file among all the other files that exist in version history after you initialize the app, and accidentally commit it.

If desired this could be changed to only include that line in the .gitignore if prisma is selected during initialization, but this way is much simpler and personally I think don't think it's an issue to just include it in .gitignore for everyone.

---

💯
