### PR TITLE
refactor: inject curried `runPkgManagerInstall` to package installers

### DIFF
--- a/src/helpers/createProject.ts
+++ b/src/helpers/createProject.ts
@@ -1,7 +1,7 @@
 import type { PkgInstallerMap } from "../installers/index.js";
 import path from "path";
 import { getUserPkgManager } from "../utils/getUserPkgManager.js";
-import { curryRunPckgManagerInstall } from "../utils/runPkgManagerInstall.js";
+import { curryRunPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 import { installPackages } from "./installPackages.js";
 import { scaffoldProject } from "./scaffoldProject.js";
 import { selectAppFile, selectIndexFile } from "./selectBoilerplate.js";
@@ -19,7 +19,7 @@ export const createProject = async ({
 }: CreateProjectOptions) => {
   const pkgManager = getUserPkgManager();
   const projectDir = path.resolve(process.cwd(), projectName);
-  const runPkgManagerInstall = curryRunPckgManagerInstall({
+  const runPkgManagerInstall = curryRunPkgManagerInstall({
     projectDir,
     pkgManager,
     devMode: false,

--- a/src/helpers/createProject.ts
+++ b/src/helpers/createProject.ts
@@ -1,6 +1,7 @@
 import type { PkgInstallerMap } from "../installers/index.js";
 import path from "path";
 import { getUserPkgManager } from "../utils/getUserPkgManager.js";
+import { curryRunPckgManagerInstall } from "../utils/runPkgManagerInstall.js";
 import { installPackages } from "./installPackages.js";
 import { scaffoldProject } from "./scaffoldProject.js";
 import { selectAppFile, selectIndexFile } from "./selectBoilerplate.js";
@@ -18,12 +19,30 @@ export const createProject = async ({
 }: CreateProjectOptions) => {
   const pkgManager = getUserPkgManager();
   const projectDir = path.resolve(process.cwd(), projectName);
+  const runPkgManagerInstall = curryRunPckgManagerInstall({
+    projectDir,
+    pkgManager,
+    devMode: false,
+    noInstallMode: noInstall,
+  });
 
   // Bootstraps the base Next.js application
-  await scaffoldProject({ projectName, projectDir, pkgManager, noInstall });
+  await scaffoldProject({
+    projectName,
+    projectDir,
+    pkgManager,
+    noInstall,
+    runPkgManagerInstall,
+  });
 
   // Install the selected packages
-  await installPackages({ projectDir, pkgManager, packages, noInstall });
+  await installPackages({
+    projectDir,
+    pkgManager,
+    packages,
+    noInstall,
+    runPkgManagerInstall,
+  });
 
   // TODO: Look into using handlebars or other templating engine to scaffold without needing to maintain multiple copies of the same file
   await selectAppFile({ projectDir, packages });

--- a/src/helpers/installPackages.ts
+++ b/src/helpers/installPackages.ts
@@ -7,12 +7,8 @@ type InstallPackagesOptions = {
   packages: PkgInstallerMap;
 } & InstallerOptions;
 // This runs the installer for all the packages that the user has selected
-export const installPackages = async ({
-  projectDir,
-  pkgManager,
-  packages,
-  noInstall,
-}: InstallPackagesOptions) => {
+export const installPackages = async (options: InstallPackagesOptions) => {
+  const { packages, noInstall } = options;
   logger.info(`${noInstall ? "Adding" : "Installing"} packages...`);
 
   for (const [name, pkgOpts] of Object.entries(packages)) {
@@ -20,7 +16,7 @@ export const installPackages = async ({
       const spinner = ora(
         `${noInstall ? "Adding" : "Installing"} ${name}...`,
       ).start();
-      await pkgOpts.installer({ projectDir, pkgManager, packages, noInstall });
+      await pkgOpts.installer(options);
       spinner.succeed(
         chalk.green(
           `Successfully ${noInstall ? "added" : "installed"} ${chalk.green.bold(

--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -1,4 +1,5 @@
 import type { PackageManager } from "../utils/getUserPkgManager.js";
+import type { CurriedRunPkgManagerInstallOptions } from "../utils/runPkgManagerInstall.js";
 import { envVariblesInstaller } from "./envVars.js";
 import { nextAuthInstaller } from "./next-auth.js";
 import { prismaInstaller } from "./prisma.js";
@@ -23,6 +24,9 @@ export interface InstallerOptions {
   noInstall: boolean;
   packages?: PkgInstallerMap;
   projectName?: string;
+  runPkgManagerInstall: (
+    opts: CurriedRunPkgManagerInstallOptions,
+  ) => Promise<void>;
 }
 
 export type Installer = (opts: InstallerOptions) => Promise<void>;

--- a/src/installers/next-auth.ts
+++ b/src/installers/next-auth.ts
@@ -2,23 +2,17 @@ import type { Installer } from "./index.js";
 import path from "path";
 import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
-import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
 export const nextAuthInstaller: Installer = async ({
-  pkgManager,
   projectDir,
+  runPkgManagerInstall,
   packages,
-  noInstall,
 }) => {
   await runPkgManagerInstall({
-    pkgManager,
-    projectDir,
     packages: [
       "next-auth",
       packages?.prisma.inUse ? "@next-auth/prisma-adapter" : "",
     ],
-    devMode: false,
-    noInstallMode: noInstall,
   });
 
   const nextAuthAssetDir = path.join(PKG_ROOT, "template/addons/next-auth");

--- a/src/installers/prisma.ts
+++ b/src/installers/prisma.ts
@@ -14,6 +14,7 @@ export const prismaInstaller: Installer = async ({
 }) => {
   await runPkgManagerInstall({
     packages: ["prisma"],
+    devMode: true,
   });
   await runPkgManagerInstall({
     packages: ["@prisma/client"],

--- a/src/installers/prisma.ts
+++ b/src/installers/prisma.ts
@@ -4,27 +4,19 @@ import path from "path";
 import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
 import { execa } from "../utils/execAsync.js";
-import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
 export const prismaInstaller: Installer = async ({
   projectDir,
+  runPkgManagerInstall,
   pkgManager,
   packages,
   noInstall,
 }) => {
   await runPkgManagerInstall({
-    pkgManager,
-    projectDir,
     packages: ["prisma"],
-    devMode: true,
-    noInstallMode: noInstall,
   });
   await runPkgManagerInstall({
-    pkgManager,
-    projectDir,
     packages: ["@prisma/client"],
-    devMode: false,
-    noInstallMode: noInstall,
   });
 
   const prismaAssetDir = path.join(PKG_ROOT, "template/addons/prisma");

--- a/src/installers/tailwind.ts
+++ b/src/installers/tailwind.ts
@@ -2,19 +2,13 @@ import type { Installer } from "./index.js";
 import path from "path";
 import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
-import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
 export const tailwindInstaller: Installer = async ({
   projectDir,
-  pkgManager,
-  noInstall,
+  runPkgManagerInstall,
 }) => {
   await runPkgManagerInstall({
-    pkgManager,
-    projectDir,
     packages: ["tailwindcss", "postcss", "autoprefixer"],
-    devMode: true,
-    noInstallMode: noInstall,
   });
 
   const twAssetDir = path.join(PKG_ROOT, "template/addons/tailwind");

--- a/src/installers/tailwind.ts
+++ b/src/installers/tailwind.ts
@@ -9,6 +9,7 @@ export const tailwindInstaller: Installer = async ({
 }) => {
   await runPkgManagerInstall({
     packages: ["tailwindcss", "postcss", "autoprefixer"],
+    devMode: true,
   });
 
   const twAssetDir = path.join(PKG_ROOT, "template/addons/tailwind");

--- a/src/installers/trpc.ts
+++ b/src/installers/trpc.ts
@@ -2,17 +2,13 @@ import type { Installer } from "./index.js";
 import path from "path";
 import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
-import { runPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
 
 export const trpcInstaller: Installer = async ({
   projectDir,
-  pkgManager,
   packages,
-  noInstall,
+  runPkgManagerInstall,
 }) => {
   await runPkgManagerInstall({
-    pkgManager,
-    projectDir,
     packages: [
       "react-query",
       "superjson",
@@ -21,8 +17,6 @@ export const trpcInstaller: Installer = async ({
       "@trpc/next",
       "@trpc/react",
     ],
-    devMode: false,
-    noInstallMode: noInstall,
   });
   const usingAuth = packages?.nextAuth.inUse;
   const usingPrisma = packages?.prisma.inUse;

--- a/src/utils/runPkgManagerInstall.ts
+++ b/src/utils/runPkgManagerInstall.ts
@@ -5,13 +5,17 @@ import { type PackageJson } from "type-fest";
 import { execa } from "./execAsync.js";
 import { logger } from "./logger.js";
 
-export const runPkgManagerInstall = async (opts: {
+export interface RunPkgManagerInstallOptions {
   pkgManager: PackageManager;
   devMode: boolean;
   projectDir: string;
   packages: string[];
   noInstallMode: boolean;
-}) => {
+}
+
+export const runPkgManagerInstall = async (
+  opts: RunPkgManagerInstallOptions,
+) => {
   const { pkgManager, devMode, projectDir, packages, noInstallMode } = opts;
 
   if (noInstallMode) {
@@ -49,4 +53,27 @@ export const runPkgManagerInstall = async (opts: {
   const flag = devMode ? "-D" : "";
   const fullCmd = `${installCmd} ${flag} ${packages.join(" ")}`;
   await execa(fullCmd, { cwd: projectDir });
+};
+
+export type CurryRunPkgManagerInstallOptions = Omit<
+  RunPkgManagerInstallOptions,
+  "packages"
+>;
+
+export type CurriedRunPkgManagerInstallOptions =
+  Partial<CurryRunPkgManagerInstallOptions> &
+    Omit<RunPkgManagerInstallOptions, keyof CurryRunPkgManagerInstallOptions>;
+
+export const curryRunPckgManagerInstall = (
+  baseOptions: CurryRunPkgManagerInstallOptions,
+) => {
+  const curriedRunPckgManagerInstall = async (
+    options: CurriedRunPkgManagerInstallOptions,
+  ) =>
+    runPkgManagerInstall({
+      ...baseOptions,
+      ...options,
+    });
+
+  return curriedRunPckgManagerInstall;
 };

--- a/src/utils/runPkgManagerInstall.ts
+++ b/src/utils/runPkgManagerInstall.ts
@@ -64,10 +64,10 @@ export type CurriedRunPkgManagerInstallOptions =
   Partial<CurryRunPkgManagerInstallOptions> &
     Omit<RunPkgManagerInstallOptions, keyof CurryRunPkgManagerInstallOptions>;
 
-export const curryRunPckgManagerInstall = (
+export const curryRunPkgManagerInstall = (
   baseOptions: CurryRunPkgManagerInstallOptions,
 ) => {
-  const curriedRunPckgManagerInstall = async (
+  const curriedRunPkgManagerInstall = async (
     options: CurriedRunPkgManagerInstallOptions,
   ) =>
     runPkgManagerInstall({
@@ -75,5 +75,5 @@ export const curryRunPckgManagerInstall = (
       ...options,
     });
 
-  return curriedRunPckgManagerInstall;
+  return curriedRunPkgManagerInstall;
 };


### PR DESCRIPTION
# Inject curried `runPkgManagerInstall` to package installers

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

I noticed that every installer had to call `runPkgManagerInstall` with a lot of configuration, but IMHO the only configuration they should specify is the `packages` list. So, this MR adds a curryable version of `runPkgManagerInstall` that is curried by `createProject` and injected to every installer as an option. This injected function has been curried with all of the necessary configuration, allowing to clear the call in each installer.

Benefits:
- cleaner code of each installer
- adding new options to `runPkgManagerInstall` will not force adding that parameter in each installer, but instead just once in the `createProject.ts` helper where it's curried
- curried options serve only as defaults, so each installer could still override the options if needed

Another small change added here passing the entirety of the options received in `installPackages.ts` to each package installer, since they share the same shape. This will also prevent from having to pass newly added options here.
