### PR TITLE
feat: migrate env + next config to esm

### DIFF
--- a/src/installers/envVars.ts
+++ b/src/installers/envVars.ts
@@ -16,20 +16,20 @@ export const envVariblesInstaller: Installer = async ({
 
   switch (true) {
     case usingAuth && usingPrisma:
-      envFile = "env-prisma-auth.js";
+      envFile = "env-prisma-auth.mjs";
       break;
     case usingAuth:
-      envFile = "env-auth.js";
+      envFile = "env-auth.mjs";
       break;
     case usingPrisma:
-      envFile = "env-prisma.js";
+      envFile = "env-prisma.mjs";
       break;
   }
 
   if (!envFile) return;
 
   const envSchemaSrc = path.join(envAssetDir, envFile);
-  const envSchemaDest = path.join(projectDir, "src/server/env-schema.js");
+  const envSchemaDest = path.join(projectDir, "src/server/env-schema.mjs");
 
   await fs.copy(envSchemaSrc, envSchemaDest, { overwrite: true });
 };

--- a/template/addons/env/env-auth.mjs
+++ b/template/addons/env/env-auth.mjs
@@ -1,10 +1,8 @@
-const { z } = require("zod");
+import { z } from "zod";
 
-const envSchema = z.object({
+export const envSchema = z.object({
   NEXTAUTH_SECRET: z.string(),
   NEXTAUTH_URL: z.string().url(),
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),
 });
-
-module.exports.envSchema = envSchema;

--- a/template/addons/env/env-prisma-auth.mjs
+++ b/template/addons/env/env-prisma-auth.mjs
@@ -1,6 +1,6 @@
-const { z } = require("zod");
+import { z } from "zod";
 
-const envSchema = z.object({
+export const envSchema = z.object({
   DATABASE_URL: z.string().url(),
   NODE_ENV: z.enum(["development", "test", "production"]),
   NEXTAUTH_SECRET: z.string(),
@@ -8,5 +8,3 @@ const envSchema = z.object({
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),
 });
-
-module.exports.envSchema = envSchema;

--- a/template/addons/env/env-prisma.mjs
+++ b/template/addons/env/env-prisma.mjs
@@ -1,8 +1,6 @@
-const { z } = require("zod");
+import { z } from "zod";
 
-const envSchema = z.object({
+export const envSchema = z.object({
   DATABASE_URL: z.string().url(),
   NODE_ENV: z.enum(["development", "test", "production"]),
 });
-
-module.exports.envSchema = envSchema;

--- a/template/addons/next-auth/api-handler-prisma.ts
+++ b/template/addons/next-auth/api-handler-prisma.ts
@@ -5,7 +5,7 @@ import CredentialsProvider from "next-auth/providers/credentials";
 // Prisma adapter for NextAuth, optional and can be removed
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { prisma } from "../../../server/db/client";
-import { env } from "../../../server/env";
+import { env } from "../../../server/env.mjs";
 
 export const authOptions: NextAuthOptions = {
   // Include user.id on session

--- a/template/addons/next-auth/api-handler.ts
+++ b/template/addons/next-auth/api-handler.ts
@@ -1,7 +1,7 @@
 import NextAuth, { type NextAuthOptions } from "next-auth";
 import DiscordProvider from "next-auth/providers/discord";
 import CredentialsProvider from "next-auth/providers/credentials";
-import { env } from "../../../server/env";
+import { env } from "../../../server/env.mjs";
 
 export const authOptions: NextAuthOptions = {
   // Include user.id on session

--- a/template/addons/prisma/client.ts
+++ b/template/addons/prisma/client.ts
@@ -1,6 +1,6 @@
 // src/server/db/client.ts
 import { PrismaClient } from "@prisma/client";
-import { env } from "../env";
+import { env } from "../env.mjs";
 
 declare global {
   var prisma: PrismaClient | undefined;

--- a/template/base/next.config.mjs
+++ b/template/base/next.config.mjs
@@ -1,8 +1,17 @@
 import { env } from "./src/server/env.mjs";
 
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-};
+/**
+ * Don't be scared of the generics here.
+ * All they do is to give us autocompletion when using this.
+ *
+ * @template {import('next').NextConfig} T
+ * @param {T} config - A generic parameter that flows through to the return type
+ * @constraint {{import('next').NextConfig}}
+ */
+function defineNextConfig(config) {
+  return config;
+}
 
-export default nextConfig;
+export default defineNextConfig({
+  reactStrictMode: true,
+});

--- a/template/base/next.config.mjs
+++ b/template/base/next.config.mjs
@@ -1,8 +1,8 @@
-const { env } = require("./src/server/env");
+import { env } from "./src/server/env.mjs";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
 };
 
-module.exports = nextConfig;
+export default nextConfig;

--- a/template/base/src/server/env-schema.js
+++ b/template/base/src/server/env-schema.js
@@ -1,7 +1,0 @@
-const { z } = require("zod");
-
-const envSchema = z.object({
-  // Specify your environment variables schema here
-});
-
-module.exports.envSchema = envSchema;

--- a/template/base/src/server/env-schema.mjs
+++ b/template/base/src/server/env-schema.mjs
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const envSchema = z.object({
+  // Specify your environment variables schema here
+});

--- a/template/base/src/server/env.mjs
+++ b/template/base/src/server/env.mjs
@@ -3,9 +3,9 @@
  * This file is included in `/next.config.js` which ensures the app isn't built with invalid env vars.
  * It has to be a `.js`-file to be imported there.
  */
-const { envSchema } = require("./env-schema");
+import { envSchema } from "./env-schema.mjs";
 
-const env = envSchema.safeParse(process.env);
+const _env = envSchema.safeParse(process.env);
 
 const formatErrors = (
   /** @type {import('zod').ZodFormattedError<Map<string,string>,string>} */
@@ -18,12 +18,12 @@ const formatErrors = (
     })
     .filter(Boolean);
 
-if (!env.success) {
+if (!_env.success) {
   console.error(
     "❌ Invalid environment variables:\n",
-    ...formatErrors(env.error.format()),
+    ...formatErrors(_env.error.format()),
   );
   process.exit(1);
 }
 
-module.exports.env = env.data;
+export const env = _env.data;

--- a/template/base/src/server/env.mjs
+++ b/template/base/src/server/env.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 /**
- * This file is included in `/next.config.js` which ensures the app isn't built with invalid env vars.
- * It has to be a `.js`-file to be imported there.
+ * This file is included in `/next.config.mjs` which ensures the app isn't built with invalid env vars.
+ * It has to be a `.mjs`-file to be imported there.
  */
 import { envSchema } from "./env-schema.mjs";
 


### PR DESCRIPTION
# Migrate CJS next config -> ESM

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

This PR renames the default `next.config` file (and its dependencies) to `.mjs`, and converts syntax within those files to ESM. Because ... why not? That's the direction we're moving in anyway, and this enables importing ESM-only packages too.
