### PR TITLE
fix: move gitignore rename call

### DIFF
--- a/src/helpers/initGit.ts
+++ b/src/helpers/initGit.ts
@@ -1,6 +1,4 @@
-import path from "path";
 import chalk from "chalk";
-import fs from "fs-extra";
 import ora from "ora";
 import { execa } from "../utils/execAsync.js";
 import { logger } from "../utils/logger.js";
@@ -32,9 +30,4 @@ export const initializeGit = async (projectDir: string) => {
       )} could not initialize git. Update git to the latest version!\n`,
     );
   }
-
-  await fs.rename(
-    path.join(projectDir, "_gitignore"),
-    path.join(projectDir, ".gitignore"),
-  );
 };

--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -57,6 +57,10 @@ export const scaffoldProject = async ({
   spinner.start();
 
   await fs.copy(srcDir, projectDir);
+  await fs.rename(
+    path.join(projectDir, "_gitignore"),
+    path.join(projectDir, ".gitignore"),
+  );
 
   if (!noInstall) {
     await execa(`${pkgManager} install`, { cwd: projectDir });


### PR DESCRIPTION
# [Move gitignore rename call to ensure correct file name]

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit
---

This fixes #212 by immediately renaming the `_gitignore` file to `.gitignore` after copying the project files.