### PR TITLE
fix: handle pkg with version in noInstall mode

### DIFF
--- a/src/utils/runPkgManagerInstall.ts
+++ b/src/utils/runPkgManagerInstall.ts
@@ -34,11 +34,13 @@ export const runPkgManagerInstall = async (
         continue;
       }
 
+      const pkgName = pkg.replace(/^(@?[^@]+)(?:@.+)?$/, "$1");
+
       // Note: We know that pkgJson.[dev]Dependencies exists in the base Next.js template so we don't need to validate it
       if (devMode) {
-        pkgJson.devDependencies![pkg] = `^${latestVersion.trim()}`; //eslint-disable-line @typescript-eslint/no-non-null-assertion
+        pkgJson.devDependencies![pkgName] = `^${latestVersion.trim()}`; //eslint-disable-line @typescript-eslint/no-non-null-assertion
       } else {
-        pkgJson.dependencies![pkg] = `^${latestVersion.trim()}`; //eslint-disable-line @typescript-eslint/no-non-null-assertion
+        pkgJson.dependencies![pkgName] = `^${latestVersion.trim()}`; //eslint-disable-line @typescript-eslint/no-non-null-assertion
       }
     }
 


### PR DESCRIPTION
# Handle adding package with hardcoded version in noInstall mode

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Fix #219 by extracting the package name using regex before putting the pkg string into dependency object.

