### PR TITLE
feat: add db.sqlite-journal to gitignore

### DIFF
--- a/template/base/_gitignore
+++ b/template/base/_gitignore
@@ -10,6 +10,7 @@
 
 # database
 /prisma/db.sqlite
+/prisma/db.sqlite-journal
 
 # next.js
 /.next/


### PR DESCRIPTION
# add db.sqlite-journal to gitignore

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

In addition to the `db.sqlite` file that is already in gitignore, sqlite can also create a journal file. This should be kept out of version control.

---

## Screenshots

<img width="213" alt="image" src="https://user-images.githubusercontent.com/8353666/179719271-86ff5234-7b38-40fb-a71c-c0fae90dff5e.png">

💯
