### PR TITLE
fix: typo - rename 'varibles' to 'variables'

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -141,7 +141,7 @@ export const runCli = async () => {
         type: "checkbox",
         message: "Which packages would you like to enable?",
         choices: availablePackages
-          .filter((pkg) => pkg !== "envVaribles") // dont prompt for env-vars
+          .filter((pkg) => pkg !== "envVariables") // dont prompt for env-vars
           .map((pkgName) => ({
             name: pkgName,
             checked: false,

--- a/src/installers/envVars.ts
+++ b/src/installers/envVars.ts
@@ -3,7 +3,7 @@ import path from "path";
 import fs from "fs-extra";
 import { PKG_ROOT } from "../consts.js";
 
-export const envVariblesInstaller: Installer = async ({
+export const envVariablesInstaller: Installer = async ({
   projectDir,
   packages,
 }) => {

--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -1,6 +1,6 @@
 import type { PackageManager } from "../utils/getUserPkgManager.js";
 import type { CurriedRunPkgManagerInstallOptions } from "../utils/runPkgManagerInstall.js";
-import { envVariblesInstaller } from "./envVars.js";
+import { envVariablesInstaller as envVariablesInstaller } from "./envVars.js";
 import { nextAuthInstaller } from "./next-auth.js";
 import { prismaInstaller } from "./prisma.js";
 import { tailwindInstaller } from "./tailwind.js";
@@ -13,7 +13,7 @@ export const availablePackages = [
   "prisma",
   "tailwind",
   "trpc",
-  "envVaribles",
+  "envVariables",
 ] as const;
 
 export type AvailablePackages = typeof availablePackages[number];
@@ -57,8 +57,8 @@ export const buildPkgInstallerMap = (
     inUse: packages.includes("trpc"),
     installer: trpcInstaller,
   },
-  envVaribles: {
+  envVariables: {
     inUse: packages.includes("prisma") || packages.includes("nextAuth"),
-    installer: envVariblesInstaller,
+    installer: envVariablesInstaller,
   },
 });


### PR DESCRIPTION
# [Short title]

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

The word 'variables' was misspelled as 'varibles' in several places in the codebase.

---

💯
