### PR TITLE
feat: check for conflicting files

### DIFF
--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -32,24 +32,35 @@ export const scaffoldProject = async ({
       );
     } else {
       spinner.stopAndPersist();
-      const { overwriteDir } = await inquirer.prompt<{ overwriteDir: boolean }>(
-        {
-          name: "overwriteDir",
-          type: "confirm",
-          message: `${chalk.redBright.bold("Warning:")} ${chalk.cyan.bold(
-            projectName,
-          )} already exists and isn't empty. Do you want to overwrite it?`,
-          default: false,
-        },
-      );
-      if (!overwriteDir) {
+      const { overwriteDir } = await inquirer.prompt<{ overwriteDir: string }>({
+        name: "overwriteDir",
+        type: "list",
+        message: `${chalk.redBright.bold("Warning:")} ${chalk.cyan.bold(
+          projectName,
+        )} already exists and isn't empty. How would you like to proceed?`,
+        choices: [
+          { name: "Clear directory", value: "clear", short: "Clear" },
+          { name: "Abort installation", value: "abort", short: "Abort" },
+          {
+            name: "Overwrite files (dangerous)",
+            value: "overwrite",
+            short: "Overwrite",
+          },
+        ],
+        default: "clear",
+      });
+      if (overwriteDir === "abort") {
         spinner.fail("Aborting installation...");
         process.exit(0);
-      } else {
+      } else if (overwriteDir === "clear") {
         spinner.info(
           `Emptying ${chalk.cyan.bold(projectName)} and creating t3 app..\n`,
         );
         fs.emptyDirSync(projectDir);
+      } else if (overwriteDir === "overwrite") {
+        spinner.info(
+          `Overwriting ${chalk.cyan.bold(projectName)} and creating t3 app..\n`,
+        );
       }
     }
   }

--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -52,22 +52,24 @@ export const scaffoldProject = async ({
       }
 
       spinner.stopAndPersist();
-      const { overwriteDir } = await inquirer.prompt<{ overwriteDir: string }>({
+      const { overwriteDir } = await inquirer.prompt<{
+        overwriteDir: "abort" | "clear" | "overwrite";
+      }>({
         name: "overwriteDir",
         type: "list",
         message: `${chalk.redBright.bold("Warning:")} ${chalk.cyan.bold(
           projectName,
         )} already exists and has conflicting files:\n${conflictingFilesStr}\n\n How would you like to proceed?`,
         choices: [
-          { name: "Clear directory", value: "clear", short: "Clear" },
           { name: "Abort installation", value: "abort", short: "Abort" },
+          { name: "Clear directory", value: "clear", short: "Clear" },
           {
             name: "Overwrite files (dangerous)",
             value: "overwrite",
             short: "Overwrite",
           },
         ],
-        default: "clear",
+        default: "abort",
       });
       if (overwriteDir === "abort") {
         spinner.fail("Aborting installation...");
@@ -77,7 +79,7 @@ export const scaffoldProject = async ({
           `Emptying ${chalk.cyan.bold(projectName)} and creating t3 app..\n`,
         );
         fs.emptyDirSync(projectDir);
-      } else if (overwriteDir === "overwrite") {
+      } else {
         spinner.info(
           `Overwriting conflicts in ${chalk.cyan.bold(
             projectName,

--- a/src/utils/getAllFiles.ts
+++ b/src/utils/getAllFiles.ts
@@ -1,16 +1,10 @@
 import path from "path";
 import fs from "fs-extra";
 
-/**
- * Find all files inside a dir, recursively.
- * https://gist.github.com/kethinov/6658166?permalink_comment_id=3379782#gistcomment-3379782
- * https://gist.github.com/kethinov/6658166?permalink_comment_id=2389484#gistcomment-2389484
- * @function getAllFiles
- * @param {string} dir Directory path string.
- * @param {string} base Base path string.
- * @return {string[]} Array with all the relative paths that are inside the directory.
- */
 export const getAllFiles = (dir: string, base = "") => {
+  // modified from
+  // https://gist.github.com/kethinov/6658166?permalink_comment_id=3379782#gistcomment-3379782
+  // https://gist.github.com/kethinov/6658166?permalink_comment_id=2389484#gistcomment-2389484
   let fileList: string[] = [];
 
   const files = fs.readdirSync(dir);

--- a/src/utils/getAllFiles.ts
+++ b/src/utils/getAllFiles.ts
@@ -1,0 +1,27 @@
+import path from "path";
+import fs from "fs-extra";
+
+/**
+ * Find all files inside a dir, recursively.
+ * https://gist.github.com/kethinov/6658166?permalink_comment_id=3379782#gistcomment-3379782
+ * https://gist.github.com/kethinov/6658166?permalink_comment_id=2389484#gistcomment-2389484
+ * @function getAllFiles
+ * @param {string} dir Directory path string.
+ * @param {string} base Base path string.
+ * @return {string[]} Array with all the relative paths that are inside the directory.
+ */
+export const getAllFiles = (dir: string, base = "") => {
+  let fileList: string[] = [];
+
+  const files = fs.readdirSync(dir);
+  for (const file of files) {
+    const fullPath = path.join(dir, file);
+    if (fs.statSync(fullPath).isDirectory()) {
+      fileList = [...fileList, ...getAllFiles(fullPath, file)];
+    } else {
+      fileList.push(path.join(base, file));
+    }
+  }
+
+  return fileList;
+};


### PR DESCRIPTION
# Check for conflicting files

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [-] I performed a functional test on my final commit

It works fine if given a project name, but I couldn't figure out how to test it with `.` as the name because `pnpm start .` fails with
 ```
> next start "."

'next' is not recognized as an internal or external command,
operable program or batch file.
```
when inside a test folder.

---

_[Short summary/description of story/feature/bugfix]_
Checks if existing files will be overwritten and adds the option to overwrite files if there are conflicts.
```
ℹ project is not empty, but no conflicting files found, continuing...
```
If there are conflicts
```
? Warning: project already exists and has conflicting files:

  project\.env-example
  project\.eslintrc.json
  project\next-env.d.ts
  project\next.config.mjs
  project\package.json
  project\public\favicon.ico
  project\README.md
  project\env\client-env.mjs
  project\env\env-schema.mjs
  project\env\server-env.mjs
  project\pages\index.tsx
  project\pages\_app.tsx
  project\styles\globals.css
  project\tsconfig.json
  project\.gitignore

 How would you like to proceed? (Use arrow keys)
❯ Clear directory
  Abort installation
  Overwrite files (dangerous)
```
---

## Screenshots

_[Screenshots]_
![image](https://user-images.githubusercontent.com/66271487/180340132-3dbe1a75-020e-43d1-88f1-0c7066bf74de.png)
![image](https://user-images.githubusercontent.com/66271487/180340188-fffb079d-c769-4f63-a91b-af17dfeaaf57.png)

💯
