### PR TITLE
feat: improved logo typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "chalk": "5.0.1",
     "commander": "^9.3.0",
-    "figlet": "^1.5.2",
     "fs-extra": "^10.1.0",
     "gradient-string": "^2.0.1",
     "inquirer": "^9.0.0",
@@ -51,7 +50,6 @@
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",
     "@commitlint/config-conventional": "^17.0.3",
-    "@types/figlet": "^1.5.4",
     "@types/fs-extra": "^9.0.13",
     "@types/gradient-string": "^1.1.2",
     "@types/inquirer": "^8.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.4
 specifiers:
   '@commitlint/cli': ^17.0.3
   '@commitlint/config-conventional': ^17.0.3
-  '@types/figlet': ^1.5.4
   '@types/fs-extra': ^9.0.13
   '@types/gradient-string': ^1.1.2
   '@types/inquirer': ^8.2.1
@@ -16,7 +15,6 @@ specifiers:
   eslint-config-prettier: ^8.5.0
   eslint-import-resolver-typescript: ^3.1.1
   eslint-plugin-import: ^2.26.0
-  figlet: ^1.5.2
   fs-extra: ^10.1.0
   gradient-string: ^2.0.1
   husky: ^8.0.1
@@ -32,7 +30,6 @@ specifiers:
 dependencies:
   chalk: 5.0.1
   commander: 9.3.0
-  figlet: 1.5.2
   fs-extra: 10.1.0
   gradient-string: 2.0.1
   inquirer: 9.0.0
@@ -41,7 +38,6 @@ dependencies:
 devDependencies:
   '@commitlint/cli': 17.0.3
   '@commitlint/config-conventional': 17.0.3
-  '@types/figlet': 1.5.4
   '@types/fs-extra': 9.0.13
   '@types/gradient-string': 1.1.2
   '@types/inquirer': 8.2.1
@@ -350,10 +346,6 @@ packages:
 
   /@tsconfig/node16/1.0.3:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
-    dev: true
-
-  /@types/figlet/1.5.4:
-    resolution: {integrity: sha512-cskPTju7glYgzvkJy/hftqw7Fen3fsd0yrPOqcbBLJu+YdDQuA438akS1g+2XVKGzsQOnXGV2I9ePv6xUBnKMQ==}
     dev: true
 
   /@types/fs-extra/9.0.13:
@@ -1854,11 +1846,6 @@ packages:
     dependencies:
       reusify: 1.0.4
     dev: true
-
-  /figlet/1.5.2:
-    resolution: {integrity: sha512-WOn21V8AhyE1QqVfPIVxe3tupJacq1xGkPTB4iagT6o+P2cAgEOOwIxMftr4+ZCTI6d551ij9j61DFr0nsP2uQ==}
-    engines: {node: '>= 0.4.0'}
-    dev: false
 
   /figures/3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -9,6 +9,10 @@ export const PKG_ROOT = path.join(distPath, "../");
 
 //export const PKG_ROOT = path.dirname(require.main.filename);
 
-export const TITLE_TEXT = `CREATE T3 APP`;
+export const TITLE_TEXT = `   ___ ___ ___   __ _____ ___   _____ ____    __   ___ ___
+  / __| _ \\ __| /  \\_   _| __| |_   _|__ /   /  \\ | _ \\ _ \\
+ | (__|   / _| / /\\ \\| | | _|    | |  |_ \\  / /\\ \\|  _/  _/
+  \\___|_|_\\___|_/‾‾\\_\\_| |___|   |_| |___/ /_/‾‾\\_\\_| |_|
+`;
 export const DEFAULT_APP_NAME = "my-t3-app";
 export const CREATE_T3_APP = "create-t3-app";

--- a/src/utils/renderTitle.ts
+++ b/src/utils/renderTitle.ts
@@ -1,4 +1,3 @@
-import figlet from "figlet";
 import gradient from "gradient-string";
 import { TITLE_TEXT } from "../consts.js";
 import { getUserPkgManager } from "./getUserPkgManager.js";
@@ -14,7 +13,6 @@ const poimandresTheme = {
 };
 
 export const renderTitle = () => {
-  const text = figlet.textSync(TITLE_TEXT, { font: "Small" });
   const t3Gradient = gradient(Object.values(poimandresTheme));
 
   // resolves weird behavior where the ascii is offset
@@ -22,5 +20,5 @@ export const renderTitle = () => {
   if (pkgManager === "yarn" || pkgManager === "pnpm") {
     console.log("");
   }
-  console.log(t3Gradient.multiline(text));
+  console.log(t3Gradient.multiline(TITLE_TEXT));
 };


### PR DESCRIPTION
# Improve logo typography

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

This PR improves the typography of the A's in the ascii logo. It also removes a dependency.

There are two obvious ways to implement this - make the ascii text a const, or read it from an external text file. I decided to make it a const, which is simpler but makes the ascii harder to read in code due to having to escape backslashes. Let me know if you prefer the other solution.

---

## Screenshots
top: before, bottom: after

<img width="634" alt="Screenshot 2022-07-22 at 14 02 08" src="https://user-images.githubusercontent.com/8353666/180435881-12a2b5c8-a090-491f-b617-1f141338d7c3.png">

💯
