### PR TITLE
fix: .env-example missing VERCEL_URL

### DIFF
--- a/template/base/.env-example
+++ b/template/base/.env-example
@@ -10,3 +10,7 @@ NEXTAUTH_URL=http://localhost:3000
 # Next Auth Discord Provider
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
+
+# Vercel
+
+VERCEL_URL=


### PR DESCRIPTION
The t3 stack uses a .env vercel url for the _app.tsx for server side rendering.

# [Short title]

- [ x ] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [ x ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ x ] I performed a functional test on my final commit

---

_[Short summary/description of story/feature/bugfix]_

---

## Screenshots

_[Screenshots]_

💯
