### PR TITLE
refactor(cli): add module path aliasing

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,13 +1,13 @@
-import type { AvailablePackages } from "../installers/index.js";
+import type { AvailablePackages } from "~/installers/index.js";
 import chalk from "chalk";
 import { Command } from "commander";
 import inquirer from "inquirer";
-import { CREATE_T3_APP, DEFAULT_APP_NAME } from "../consts.js";
-import { availablePackages } from "../installers/index.js";
-import { getVersion } from "../utils/getT3Version.js";
-import { getUserPkgManager } from "../utils/getUserPkgManager.js";
-import { logger } from "../utils/logger.js";
-import { validateAppName } from "../utils/validateAppName.js";
+import { CREATE_T3_APP, DEFAULT_APP_NAME } from "~/consts.js";
+import { availablePackages } from "~/installers/index.js";
+import { getVersion } from "~/utils/getT3Version.js";
+import { getUserPkgManager } from "~/utils/getUserPkgManager.js";
+import { logger } from "~/utils/logger.js";
+import { validateAppName } from "~/utils/validateAppName.js";
 
 interface CliFlags {
   noGit: boolean;

--- a/src/helpers/createProject.ts
+++ b/src/helpers/createProject.ts
@@ -1,10 +1,10 @@
-import type { PkgInstallerMap } from "../installers/index.js";
+import type { PkgInstallerMap } from "~/installers/index.js";
 import path from "path";
-import { getUserPkgManager } from "../utils/getUserPkgManager.js";
-import { curryRunPkgManagerInstall } from "../utils/runPkgManagerInstall.js";
-import { installPackages } from "./installPackages.js";
-import { scaffoldProject } from "./scaffoldProject.js";
-import { selectAppFile, selectIndexFile } from "./selectBoilerplate.js";
+import { installPackages } from "~/helpers/installPackages.js";
+import { scaffoldProject } from "~/helpers/scaffoldProject.js";
+import { selectAppFile, selectIndexFile } from "~/helpers/selectBoilerplate.js";
+import { getUserPkgManager } from "~/utils/getUserPkgManager.js";
+import { curryRunPkgManagerInstall } from "~/utils/runPkgManagerInstall.js";
 
 interface CreateProjectOptions {
   projectName: string;

--- a/src/helpers/initGit.ts
+++ b/src/helpers/initGit.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import ora from "ora";
-import { execa } from "../utils/execAsync.js";
-import { logger } from "../utils/logger.js";
+import { execa } from "~/utils/execAsync.js";
+import { logger } from "~/utils/logger.js";
 
 // This initializes the Git-repository for the project
 export const initializeGit = async (projectDir: string) => {

--- a/src/helpers/installPackages.ts
+++ b/src/helpers/installPackages.ts
@@ -1,7 +1,7 @@
 import type { InstallerOptions, PkgInstallerMap } from "../installers/index.js";
 import chalk from "chalk";
 import ora from "ora";
-import { logger } from "../utils/logger.js";
+import { logger } from "~/utils/logger.js";
 
 type InstallPackagesOptions = {
   packages: PkgInstallerMap;

--- a/src/helpers/logNextSteps.ts
+++ b/src/helpers/logNextSteps.ts
@@ -1,7 +1,7 @@
-import type { InstallerOptions } from "../installers/index.js";
-import { DEFAULT_APP_NAME } from "../consts.js";
-import { getUserPkgManager } from "../utils/getUserPkgManager.js";
-import { logger } from "../utils/logger.js";
+import type { InstallerOptions } from "~/installers/index.js";
+import { DEFAULT_APP_NAME } from "~/consts.js";
+import { getUserPkgManager } from "~/utils/getUserPkgManager.js";
+import { logger } from "~/utils/logger.js";
 
 // This logs the next steps that the user should take in order to advance the project
 export const logNextSteps = ({

--- a/src/helpers/scaffoldProject.ts
+++ b/src/helpers/scaffoldProject.ts
@@ -3,10 +3,10 @@ import chalk from "chalk";
 import fs from "fs-extra";
 import inquirer from "inquirer";
 import ora from "ora";
-import { PKG_ROOT } from "../consts.js";
-import { InstallerOptions } from "../installers/index.js";
-import { execa } from "../utils/execAsync.js";
-import { logger } from "../utils/logger.js";
+import { PKG_ROOT } from "~/consts.js";
+import { InstallerOptions } from "~/installers/index.js";
+import { execa } from "~/utils/execAsync.js";
+import { logger } from "~/utils/logger.js";
 
 // This bootstraps the base Next.js application
 export const scaffoldProject = async ({

--- a/src/helpers/selectBoilerplate.ts
+++ b/src/helpers/selectBoilerplate.ts
@@ -1,7 +1,7 @@
-import type { InstallerOptions } from "../installers/index.js";
+import type { InstallerOptions } from "~/installers/index.js";
 import path from "path";
 import fs from "fs-extra";
-import { PKG_ROOT } from "../consts.js";
+import { PKG_ROOT } from "~/consts.js";
 
 type SelectBoilerplateProps = Required<
   Pick<InstallerOptions, "projectDir" | "packages">

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,14 @@
 import type { PackageJson } from "type-fest";
 import path from "path";
 import fs from "fs-extra";
-import { runCli } from "./cli/index.js";
-import { createProject } from "./helpers/createProject.js";
-import { initializeGit } from "./helpers/initGit.js";
-import { logNextSteps } from "./helpers/logNextSteps.js";
-import { buildPkgInstallerMap } from "./installers/index.js";
-import { logger } from "./utils/logger.js";
-import { parseNameAndPath } from "./utils/parseNameAndPath.js";
-import { renderTitle } from "./utils/renderTitle.js";
+import { runCli } from "~/cli/index.js";
+import { createProject } from "~/helpers/createProject.js";
+import { initializeGit } from "~/helpers/initGit.js";
+import { logNextSteps } from "~/helpers/logNextSteps.js";
+import { buildPkgInstallerMap } from "~/installers/index.js";
+import { logger } from "~/utils/logger.js";
+import { parseNameAndPath } from "~/utils/parseNameAndPath.js";
+import { renderTitle } from "~/utils/renderTitle.js";
 
 const main = async () => {
   renderTitle();

--- a/src/installers/envVars.ts
+++ b/src/installers/envVars.ts
@@ -1,7 +1,7 @@
-import type { Installer } from "./index.js";
+import type { Installer } from "~/installers/index.js";
 import path from "path";
 import fs from "fs-extra";
-import { PKG_ROOT } from "../consts.js";
+import { PKG_ROOT } from "~/consts.js";
 
 export const envVariablesInstaller: Installer = async ({
   projectDir,

--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -1,10 +1,10 @@
-import type { PackageManager } from "../utils/getUserPkgManager.js";
-import type { CurriedRunPkgManagerInstallOptions } from "../utils/runPkgManagerInstall.js";
-import { envVariablesInstaller as envVariablesInstaller } from "./envVars.js";
-import { nextAuthInstaller } from "./next-auth.js";
-import { prismaInstaller } from "./prisma.js";
-import { tailwindInstaller } from "./tailwind.js";
-import { trpcInstaller } from "./trpc.js";
+import type { PackageManager } from "~/utils/getUserPkgManager.js";
+import type { CurriedRunPkgManagerInstallOptions } from "~/utils/runPkgManagerInstall.js";
+import { envVariablesInstaller as envVariablesInstaller } from "~/installers/envVars.js";
+import { nextAuthInstaller } from "~/installers/next-auth.js";
+import { prismaInstaller } from "~/installers/prisma.js";
+import { tailwindInstaller } from "~/installers/tailwind.js";
+import { trpcInstaller } from "~/installers/trpc.js";
 
 // Turning this into a const allows the list to be iterated over for programatically creating prompt options
 // Should increase extensability in the future

--- a/src/installers/next-auth.ts
+++ b/src/installers/next-auth.ts
@@ -1,7 +1,7 @@
-import type { Installer } from "./index.js";
+import type { Installer } from "~/installers/index.js";
 import path from "path";
 import fs from "fs-extra";
-import { PKG_ROOT } from "../consts.js";
+import { PKG_ROOT } from "~/consts.js";
 
 export const nextAuthInstaller: Installer = async ({
   projectDir,

--- a/src/installers/prisma.ts
+++ b/src/installers/prisma.ts
@@ -1,9 +1,9 @@
-import type { Installer } from "./index.js";
 import type { PackageJson } from "type-fest";
+import type { Installer } from "~/installers/index.js";
 import path from "path";
 import fs from "fs-extra";
-import { PKG_ROOT } from "../consts.js";
-import { execa } from "../utils/execAsync.js";
+import { PKG_ROOT } from "~/consts.js";
+import { execa } from "~/utils/execAsync.js";
 
 export const prismaInstaller: Installer = async ({
   projectDir,

--- a/src/installers/tailwind.ts
+++ b/src/installers/tailwind.ts
@@ -1,7 +1,7 @@
-import type { Installer } from "./index.js";
+import type { Installer } from "~/installers/index.js";
 import path from "path";
 import fs from "fs-extra";
-import { PKG_ROOT } from "../consts.js";
+import { PKG_ROOT } from "~/consts.js";
 
 export const tailwindInstaller: Installer = async ({
   projectDir,

--- a/src/installers/trpc.ts
+++ b/src/installers/trpc.ts
@@ -1,7 +1,7 @@
-import type { Installer } from "./index.js";
+import type { Installer } from "~/installers/index.js";
 import path from "path";
 import fs from "fs-extra";
-import { PKG_ROOT } from "../consts.js";
+import { PKG_ROOT } from "~/consts.js";
 
 export const trpcInstaller: Installer = async ({
   projectDir,

--- a/src/utils/getT3Version.ts
+++ b/src/utils/getT3Version.ts
@@ -1,7 +1,7 @@
 import type { PackageJson } from "type-fest";
 import path from "path";
 import fs from "fs-extra";
-import { PKG_ROOT } from "../consts.js";
+import { PKG_ROOT } from "~/consts.js";
 
 export const getVersion = () => {
   const packageJsonPath = path.join(PKG_ROOT, "package.json");

--- a/src/utils/renderTitle.ts
+++ b/src/utils/renderTitle.ts
@@ -1,6 +1,6 @@
 import gradient from "gradient-string";
-import { TITLE_TEXT } from "../consts.js";
-import { getUserPkgManager } from "./getUserPkgManager.js";
+import { TITLE_TEXT } from "~/consts.js";
+import { getUserPkgManager } from "~/utils/getUserPkgManager.js";
 
 // colors brought in from vscode poimandres theme
 const poimandresTheme = {

--- a/src/utils/runPkgManagerInstall.ts
+++ b/src/utils/runPkgManagerInstall.ts
@@ -1,9 +1,9 @@
-import type { PackageManager } from "./getUserPkgManager.js";
+import type { PackageManager } from "~/utils/getUserPkgManager.js";
 import path from "path";
 import fs from "fs-extra";
 import { type PackageJson } from "type-fest";
-import { execa } from "./execAsync.js";
-import { logger } from "./logger.js";
+import { execa } from "~/utils/execAsync.js";
+import { logger } from "~/utils/logger.js";
 
 export interface RunPkgManagerInstallOptions {
   pkgManager: PackageManager;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,12 @@
     // "exactOptionalPropertyTypes": true, // TLDR - Setting to undefined is not the same as a property not being defined at all
     // "noPropertyAccessFromIndexSignature": true, // TLDR - Use dot notation for objects if youre sure it exists, use ['index'] notaion if unsure
 
+    /* MODULE PATH ALIAS*/
+    "baseUrl": "./",
+    "paths": {
+      "~/*": ["./src/*"]
+    },
+
     /* OTHER OPTIONS */
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,


### PR DESCRIPTION
# Add path alias configuration in ts config


- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

_Summary_
---
close #206 by adding path alias into tsconfig.json

