### PR TITLE
fix: height on small viewports

### DIFF
--- a/template/page-studs/index/with-auth-trpc-tw.tsx
+++ b/template/page-studs/index/with-auth-trpc-tw.tsx
@@ -41,7 +41,7 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="container mx-auto flex flex-col items-center justify-center h-screen p-4">
+      <main className="container mx-auto flex flex-col items-center justify-center min-h-screen p-4">
         <h1 className="text-5xl md:text-[5rem] leading-normal font-extrabold text-gray-700">
           Create <span className="text-purple-300">T3</span> App
         </h1>

--- a/template/page-studs/index/with-trpc-tw.tsx
+++ b/template/page-studs/index/with-trpc-tw.tsx
@@ -19,7 +19,7 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="container mx-auto flex flex-col items-center justify-center h-screen p-4">
+      <main className="container mx-auto flex flex-col items-center justify-center min-h-screen p-4">
         <h1 className="text-5xl md:text-[5rem] leading-normal font-extrabold text-gray-700">
           Create <span className="text-purple-300">T3</span> App
         </h1>

--- a/template/page-studs/index/with-tw.tsx
+++ b/template/page-studs/index/with-tw.tsx
@@ -16,7 +16,7 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="container mx-auto flex flex-col items-center justify-center h-screen p-4">
+      <main className="container mx-auto flex flex-col items-center justify-center min-h-screen p-4">
         <h1 className="text-5xl md:text-[5rem] leading-normal font-extrabold text-gray-700">
           Create <span className="text-purple-300">T3</span> App
         </h1>


### PR DESCRIPTION
# [Short title]

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Currently, with Tailwind selected some of the content gets pushed offscreen on small viewports and cannot be scrolled property. I fixed this by changing container height to min-height.

---

## Screenshots

Before:
<img width="788" alt="Screenshot 2022-07-26 at 08 44 12" src="https://user-images.githubusercontent.com/8353666/180941750-0e188ab0-09cc-4225-bbd0-3cd169ea6b25.png">

After:
<img width="788" alt="Screenshot 2022-07-26 at 08 44 19" src="https://user-images.githubusercontent.com/8353666/180941770-3346b23d-5376-4681-8459-f49da6495b9d.png">

💯

