### PR TITLE
feat: set appName to directory on 'npx create-t3-app .'

### DIFF
--- a/src/utils/parseNameAndPath.ts
+++ b/src/utils/parseNameAndPath.ts
@@ -2,6 +2,7 @@
  *  Parses the appName and its path from the user input.
  * Returns an array of [appName, path] where appName is the name put in the package.json and
  *   path is the path to the directory where the app will be created.
+ * If the appName is '.', the name of the directory will be used instead.
  * Handles the case where the input includes a scoped package name
  * in which case that is being parsed as the name, but not included as the path
  * e.g. dir/@mono/app => ["@mono/app", "dir/app"]
@@ -11,6 +12,11 @@ export const parseNameAndPath = (input: string) => {
   const paths = input.split("/");
 
   let appName = paths[paths.length - 1];
+
+  // If the user ran `npx create-t3-app .` or similar, the appName should be the current directory
+  if (appName === ".") {
+    appName = process.cwd().split("/").pop();
+  }
 
   // If the first part is a @, it's a scoped package
   const indexOfDelimiter = paths.findIndex((p) => p.startsWith("@"));


### PR DESCRIPTION
# set appName to directory on 'npx create-t3-app .'

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

resolves https://github.com/t3-oss/create-t3-app/issues/269

Before, when running create-t3-app with '.' as the name argument (ie to init inside the current folder), the `name` in package.json was also set to `.`. With this pr, the folder name is used instead in that case. This is the same behaviour as many other tools such as create-next-app.

💯
