### PR TITLE
fix(prisma): make db changes for next-auth on mysql obvious

### DIFF
--- a/template/addons/prisma/auth-schema.prisma
+++ b/template/addons/prisma/auth-schema.prisma
@@ -6,7 +6,11 @@ generator client {
 }
 
 datasource db {
-    provider = "sqlite" // NOTE: sqlite does not work with NextAuth.js
+    provider = "sqlite"
+    // NOTE: When using postgresql, mysql or sqlserver, uncomment the @db.text annotations in model Account below
+    // Further reading: 
+    // https://next-auth.js.org/adapters/prisma#create-the-prisma-schema
+    // https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string
     url      = env("DATABASE_URL")
 }
 
@@ -21,12 +25,12 @@ model Account {
     type              String
     provider          String
     providerAccountId String
-    refresh_token     String?
-    access_token      String?
+    refresh_token     String? //@db.Text
+    access_token      String? //@db.Text
     expires_at        Int?
     token_type        String?
     scope             String?
-    id_token          String?
+    id_token          String? //@db.Text
     session_state     String?
     user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
# auth-schema migration hints

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

As discussed in #271, switching to MySQL with the current `auth-schema.prisma` can result in unexpected login behavior due to different default `String?` mappings in prisma. This change allows the user to quickstart with `sqlite` but makes it obvious that changes to the schema need to be made when switchting to `postgresql`, `mysql` or `sqlserver`.
