### PR TITLE
Fix import path for unstable_getServerSession

### DIFF
--- a/template/addons/next-auth/restricted.ts
+++ b/template/addons/next-auth/restricted.ts
@@ -1,7 +1,7 @@
 // Example of a restricted endpoint that only authenticated users can access from https://next-auth.js.org/getting-started/example
 
 import { NextApiRequest, NextApiResponse } from "next";
-import { unstable_getServerSession as getServerSession } from "next-auth";
+import { unstable_getServerSession as getServerSession } from "next-auth/next";
 import { authOptions as nextAuthOptions } from "./auth/[...nextauth]";
 
 const restricted = async (req: NextApiRequest, res: NextApiResponse) => {


### PR DESCRIPTION
Module '"next-auth"' has no exported member 'unstable_getServerSession'.ts

# [Short title]

- [ ] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

_[Short summary/description of story/feature/bugfix]_

---

## Screenshots

_[Screenshots]_

💯
