### PR TITLE
fix(prisma): fix minor typo in prisma schema

### DIFF
--- a/template/addons/prisma/auth-schema.prisma
+++ b/template/addons/prisma/auth-schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
     provider = "sqlite"
-    // NOTE: When using postgresql, mysql or sqlserver, uncomment the @db.text annotations in model Account below
+    // NOTE: When using postgresql, mysql or sqlserver, uncomment the @db.Text annotations in model Account below
     // Further reading: 
     // https://next-auth.js.org/adapters/prisma#create-the-prisma-schema
     // https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string
@@ -25,12 +25,12 @@ model Account {
     type              String
     provider          String
     providerAccountId String
-    refresh_token     String? // @db.text
-    access_token      String? // @db.text
+    refresh_token     String? // @db.Text
+    access_token      String? // @db.Text
     expires_at        Int?
     token_type        String?
     scope             String?
-    id_token          String? // @db.text
+    id_token          String? // @db.Text
     session_state     String?
     user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
# Fix minor typo in prisma schema

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---
Fixed small typo in auth-schema.prisma (changed @db.text to @db.Text)  to address    #277 

Refrence: https://www.prisma.io/docs/concepts/database-connectors/postgresql

---

