### PR TITLE
feat: make session.user.id non-nullable

### DIFF
--- a/template/addons/next-auth/next-auth.d.ts
+++ b/template/addons/next-auth/next-auth.d.ts
@@ -6,7 +6,7 @@ declare module "next-auth" {
    */
   interface Session {
     user?: {
-      id?: string;
+      id: string;
     } & DefaultSession["user"];
   }
 }


### PR DESCRIPTION
# feat: make session.user.id non-nullable

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Resolves https://github.com/t3-oss/create-t3-app/issues/281

Makes `session.user.id` non-nullable, resulting in fewer guard clauses without . For further thoughts see https://github.com/t3-oss/create-t3-app/issues/281.

This changes behaviour that was discussed extensively in https://github.com/t3-oss/create-t3-app/pull/180#issuecomment-1182760580, however in that PR the only options discussed were both user and user.id nullable, or both user and user.id non nullable, not user nullable but user.id non nullable.

Open for comments though :)

---

## Screenshots

<img width="513" alt="image" src="https://user-images.githubusercontent.com/8353666/183159355-1519e171-ed35-421d-ab3b-4aaa5f2f15a7.png">


💯
