### PR TITLE
fix: inverse the optional made in #284 to match #282

### DIFF
--- a/template/addons/next-auth/next-auth.d.ts
+++ b/template/addons/next-auth/next-auth.d.ts
@@ -5,8 +5,8 @@ declare module "next-auth" {
    * Returned by `useSession`, `getSession` and received as a prop on the `SessionProvider` React Context
    */
   interface Session {
-    user: {
-      id?: string;
+    user?: {
+      id: string;
     } & DefaultSession["user"];
   }
 }


### PR DESCRIPTION
# Fixes #284 by matching #282 

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Main:
https://github.com/t3-oss/create-t3-app/blob/6a81f03bfafdf77c1c82b7972a97e3e54d77935c/template/addons/next-auth/next-auth.d.ts#L7-L11

Next:
https://github.com/t3-oss/create-t3-app/blob/7627d2292c30d8c3027d4e21c530cb6f9de6bf71/template/addons/next-auth/next-auth.d.ts#L7-L11

---
