### PR TITLE
feat: tailwind classes react props mapping

### DIFF
--- a/template/page-studs/index/with-tw.tsx
+++ b/template/page-studs/index/with-tw.tsx
@@ -8,6 +8,8 @@ type TechnologyCardProps = {
 };
 
 export type Variant<T extends string> = { [P in T]: string };
+
+export type ColorToken = "red" | "green" | "blue" | "purple" | "gray";
 const Home: NextPage = () => {
   return (
     <>

--- a/template/page-studs/index/with-tw.tsx
+++ b/template/page-studs/index/with-tw.tsx
@@ -7,6 +7,7 @@ type TechnologyCardProps = {
   documentation: string;
 };
 
+export type Variant<T extends string> = { [P in T]: string };
 const Home: NextPage = () => {
   return (
     <>

--- a/template/page-studs/index/with-tw.tsx
+++ b/template/page-studs/index/with-tw.tsx
@@ -10,6 +10,15 @@ type TechnologyCardProps = {
 export type Variant<T extends string> = { [P in T]: string };
 
 export type ColorToken = "red" | "green" | "blue" | "purple" | "gray";
+
+const colors: Variant<ColorToken> = {
+  red: "text-red-300",
+  blue: "text-blue-500",
+  green: "text-green-400",
+  gray: "text-gray-700",
+  purple: "text-purple-300",
+};
+
 const Home: NextPage = () => {
   return (
     <>

--- a/template/page-studs/index/with-tw.tsx
+++ b/template/page-studs/index/with-tw.tsx
@@ -55,6 +55,20 @@ const Home: NextPage = () => {
   );
 };
 
+const Headline: React.FC<{ color?: ColorToken; children: React.ReactNode }> = ({
+  color = "gray",
+  children,
+}) => (
+  <h1
+    className={[
+      "text-5xl md:text-[5rem] leading-normal font-extrabold",
+      colors[color],
+    ].join(" ")}
+  >
+    {children}
+  </h1>
+);
+
 const TechnologyCard = ({
   name,
   description,

--- a/template/page-studs/index/with-tw.tsx
+++ b/template/page-studs/index/with-tw.tsx
@@ -29,9 +29,9 @@ const Home: NextPage = () => {
       </Head>
 
       <main className="container mx-auto flex flex-col items-center justify-center min-h-screen p-4">
-        <h1 className="text-5xl md:text-[5rem] leading-normal font-extrabold text-gray-700">
-          Create <span className="text-purple-300">T3</span> App
-        </h1>
+        <Headline>
+          Create <span className={colors["purple"]}>T3</span> App
+        </Headline>
         <p className="text-2xl text-gray-700">This stack uses:</p>
         <div className="grid gap-3 pt-3 mt-3 text-center md:grid-cols-3 lg:w-2/3">
           <TechnologyCard


### PR DESCRIPTION
# Map React Props to TailwindCSS classes to create reusable Style Tokens

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

**You might want to ignore the "steps" WOT … you can just look at the source + commit history**

I kind of hate that Tailwind just litters your markup with classes and makes shit harder to read and it annoys the living shit out of me (CSS isn't THAT).
BUT ... unfortunately it's the best tooling / solution we've got for now so that's that.

Anyways. 

---

What this code is doing, is mapping React Props onto TS Objects in a way, that the "variant objects" are reusable for other components and can be defined in a single file (usually … not in this example). This enables developers to work with props again instead of classes because passing classnames makes the whole component thing useless in styling terms.

It's simple but made my life sooo much easier (I got to mention that I am a designer who codes components that frontend teams use without having to think about how they look). It's kind of a necessity for our projects that styles can be applied via props instead of classes.

---

So here's what's happening (feel free to ignore steps WOT and jump to commit history / code instead).

1. Create the base `Variant` type. (optional)
This is just a dumbed down version of a `Record<YourPropName, string>` to make things a bit easier.
```typescript
type Variant<T> = { [P in T]: string };
``` 

2. Create the Token type that you need.
This can be literally just anything you want to map onto the string.
```typescript
type ColorToken = "blue" | "red" | "black";
```

3. Crate the `Variant` object.
Object is used here so typescript screams at you if you forget one of the options.
```typescript
const colors: Variant<ColorToken> = {
  blue: "text-blue-500",
  red: "text-red-300 font-semibold",
  black: "text-gray-700 text-sm",
};
```

4. Add the Token to the component.
```typescript
interface ComponentProps {
  color?: ColorToken;
}

const FancyComponent = ({ color = "black" }) => (
 <div className={ colors[color] }>Example Text</div>
);
```

5. Use Prop like usual prop
```typescript
<FancyComponent color="red" />
```

**Limitations of this approach**
- There is no Tailwind class autocompletion / IntelliSense / whatever it's called.
If there is a typo in the css classes part yer fucked. From what i've seen Tailwind doesn't export a Type definition for their classnames. This could be better but for me it's a minor tradeoff.

**Benefits of this approach**
- Variants can be reused in other components (I usually collect them in a separate variants.ts file).
- If you have to add a variant you simply extend the Token type + object and your done (no need to touch the component).
- Variants can be relatively complex (e.g. typography tokens can be a set of line-height, leading, weight, etc.).

I kinda got inspired to share this solution with the t3-oss crowd when I lurked in Theo's "In defence of Tailwind" twitter space today morning (for SF it's night I guess :P). I love the spirit of this community so much that I wanted to contribute something.

If you'd like to express your opinion about this, feel free to do so in whatever fashion you fancy ... I am too lazy and old for nice words, just speak your mind, I can take it. If for whatever reason this approach makes you vomit / scream, please let me know. As I mentioned I am more a designer than a programmer so the solution has great potential to just be trash - if so I'd be happy to get some feedback so I can further learn and improve.

---

## Screenshots

No screenshot. Just code. (Explained above and in commit history).

💯
