### PR TITLE
docs: update tRPC v10 docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ yarn create t3-app
 pnpm dlx create-t3-app@latest
 ```
 
-If you prefer using the [experimental v10 version of tRPC](https://github.com/trpc/trpc/blob/next/.tmp/v10-docs.md), use `create-t3-app@next`. Note that the alpha versions of tRPC that it uses may contain API changes. We will try our best to keep on top of these, please file an issue if we have missed something.
+If you prefer using the [experimental v10 version of tRPC](https://alpha.trpc.io/), use `create-t3-app@next`. Note that the alpha versions of tRPC that it uses may contain API changes. We will try our best to keep on top of these, please file an issue if we have missed something.
 
 An ongoing development branch, `create-t3-app@beta`, can be downloaded for the most recent changes. Expect bugs when using the `beta` branch and please open issues with reproductions when they occur.
 


### PR DESCRIPTION
# Update tRPC v10 docs link

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

Per a discussion in the tRPC discord server (in the thread at <https://discord.com/channels/867764511159091230/1006027755755946054>), the link to the documentation of the alpha version of tRPC should link to the new alpha docs instead of a temporary README that may be deleted soon.

---

## Screenshots

<details>
  <summary>Screenshots of thread for archival purposes:</summary>

![image](https://user-images.githubusercontent.com/29130894/183349903-8ef979ee-18ea-41dd-832f-76a1160e7ce6.png)
![image](https://user-images.githubusercontent.com/29130894/183349919-7d3475d7-699b-46c0-bb22-82d17ffe33cc.png)
</details>

💯
