### PR TITLE
fix: parse path returned from process.cwd() before using it

### DIFF
--- a/src/utils/parseNameAndPath.ts
+++ b/src/utils/parseNameAndPath.ts
@@ -1,3 +1,5 @@
+import pathModule from "path";
+
 /**
  *  Parses the appName and its path from the user input.
  * Returns an array of [appName, path] where appName is the name put in the package.json and
@@ -15,7 +17,8 @@ export const parseNameAndPath = (input: string) => {
 
   // If the user ran `npx create-t3-app .` or similar, the appName should be the current directory
   if (appName === ".") {
-    appName = process.cwd().split("/").pop();
+    const parsedCwd = pathModule.resolve(process.cwd());
+    appName = pathModule.basename(parsedCwd);
   }
 
   // If the first part is a @, it's a scoped package


### PR DESCRIPTION
# Fix package name error mentioned in #302 

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

### Describe the bug

https://github.com/t3-oss/create-t3-app/blob/f060d59a4e53a6932c5dd9620a20efa7d1c96241/src/utils/parseNameAndPath.ts#L16-L19

On windows, process.cwd() returns something like: `D:\\path\\to\\project`, which breaks the above code since it uses `\\` instead of `/` to separate efferent segments of path.
Consequently, project generated by `create t3 app` will use an invalid app name:
![image](https://user-images.githubusercontent.com/57709309/183903030-07a0efd0-7863-4d07-b627-1dd4fe71cf24.png)

### Changes

This PR uses nodejs's builtin path module to parse the path returned by process.cwd() before consuming it, ensures windows users get correct package name.