### PR TITLE
feat: Include ct3a version as metadata in generated app

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
-import type { PackageJson } from "type-fest";
 import path from "path";
 import fs from "fs-extra";
 import { runCli } from "~/cli/index.js";
 import { createProject } from "~/helpers/createProject.js";
 import { initializeGit } from "~/helpers/initGit.js";
 import { logNextSteps } from "~/helpers/logNextSteps.js";
-import { buildPkgInstallerMap } from "~/installers/index.js";
+import { buildPkgInstallerMap, CT3APackageJSON } from "~/installers/index.js";
 import { logger } from "~/utils/logger.js";
 import { parseNameAndPath } from "~/utils/parseNameAndPath.js";
 import { renderTitle } from "~/utils/renderTitle.js";
+import { getVersion } from "./utils/getT3Version.js";
 
 const main = async () => {
   renderTitle();
@@ -38,8 +38,9 @@ const main = async () => {
   logNextSteps({ projectName: appDir, packages: usePackages, noInstall });
   const pkgJson = (await fs.readJSON(
     path.join(projectDir, "package.json"),
-  )) as PackageJson;
+  )) as CT3APackageJSON;
   pkgJson.name = scopedAppName;
+  pkgJson.ct3aMetadata = { initVersion: getVersion() };
   await fs.writeJSON(path.join(projectDir, "package.json"), pkgJson, {
     spaces: 2,
   });

--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -1,3 +1,4 @@
+import type { PackageJson } from "type-fest";
 import type { PackageManager } from "~/utils/getUserPkgManager.js";
 import type { CurriedRunPkgManagerInstallOptions } from "~/utils/runPkgManagerInstall.js";
 import { envVariablesInstaller as envVariablesInstaller } from "~/installers/envVars.js";
@@ -62,3 +63,9 @@ export const buildPkgInstallerMap = (
     installer: envVariablesInstaller,
   },
 });
+
+export type CT3APackageJSON = PackageJson & {
+  ct3aMetadata?: {
+    initVersion: string;
+  };
+};


### PR DESCRIPTION
# Include ct3a version as metadata in generated app

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Resolves #298

Let me know if you want:
- the type moved to src/index.ts (I feel like it putting it next to the other types makes sense, but don't care strongly about it)
- you want the same on the next branch

💯
