### PR TITLE
feat: include ct3a version as metadata (next)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,13 @@ import { logger } from "~/utils/logger.js";
 import { parseNameAndPath } from "~/utils/parseNameAndPath.js";
 import { renderTitle } from "~/utils/renderTitle.js";
 import { installDependencies } from "./helpers/installDependencies.js";
+import { getVersion } from "./utils/getT3Version.js";
+
+type CT3APackageJSON = PackageJson & {
+  ct3aMetadata?: {
+    initVersion: string;
+  };
+};
 
 const main = async () => {
   renderTitle();
@@ -45,8 +52,9 @@ const main = async () => {
   // Write name to package.json
   const pkgJson = fs.readJSONSync(
     path.join(projectDir, "package.json"),
-  ) as PackageJson;
+  ) as CT3APackageJSON;
   pkgJson.name = scopedAppName;
+  pkgJson.ct3aMetadata = { initVersion: getVersion() };
   fs.writeJSONSync(path.join(projectDir, "package.json"), pkgJson, {
     spaces: 2,
   });


### PR DESCRIPTION
# include ct3a version as metadata (next)

- [x] I reviewed linter warnings + errors, resolved formatting, types and other issues related to my work
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

Same as https://github.com/t3-oss/create-t3-app/pull/305 but on next

---

## Screenshots

<img width="365" alt="image" src="https://user-images.githubusercontent.com/8353666/184225975-923c83e9-d3dc-49ed-b001-477d3763a79e.png">

💯
