### PR TITLE
fix: process.browser is deprecated use process typeof window

### DIFF
--- a/template/page-studs/_app/with-trpc.tsx
+++ b/template/page-studs/_app/with-trpc.tsx
@@ -13,7 +13,7 @@ const getBaseUrl = () => {
   if (typeof window !== "undefined") {
     return "";
   }
-  if (process.browser) return ""; // Browser should use current path
+  if (typeof window) return ""; // Browser should use current path
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // SSR should use vercel url
 
   return `http://localhost:${process.env.PORT ?? 3000}`; // dev SSR should use localhost


### PR DESCRIPTION
Just a simple fix of a deprecated check. Thank you so much for this awesome project. Much easier than setting it up myself over and over again!