### PR TITLE
chore: ignore package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 node_modules/
 /.pnp
 .pnp.js
+package-lock.json
+yarn.lock
 
 # TESTING
 /coverage


### PR DESCRIPTION
testing ci run