### PR TITLE
fix: use auth instead of question while merging the router

### DIFF
--- a/.changeset/cyan-bags-sit.md
+++ b/.changeset/cyan-bags-sit.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+use auth instead of question while merging the router

--- a/cli/template/addons/trpc/auth-index-router.ts
+++ b/cli/template/addons/trpc/auth-index-router.ts
@@ -8,7 +8,7 @@ import { protectedExampleRouter } from "./protected-example-router";
 export const appRouter = createRouter()
   .transformer(superjson)
   .merge("example.", exampleRouter)
-  .merge("question.", protectedExampleRouter);
+  .merge("auth.", protectedExampleRouter);
 
 // export type definition of API
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

## Changelog

<p>
While scaffolding a project with Next Auth and tRPC, there is a `protected-example-router` to show how to protect tRPC routers with Next Auth. This router is merged as `question.` in the index file. But in `src/pages/index.tsx`, the query is called using `auth.getSecretMessage` which will obviously fail because its `question.getSecretMessage`. This PR fixes it and merges the router as `auth.`.
</p>
