### PR TITLE
fix: build fails on trpc, trpc+prisma

### DIFF
--- a/.changeset/rude-bags-fetch.md
+++ b/.changeset/rude-bags-fetch.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: build fails on trpc, trpc+next

--- a/cli/template/addons/trpc/base-context.ts
+++ b/cli/template/addons/trpc/base-context.ts
@@ -2,7 +2,10 @@
 import * as trpc from "@trpc/server";
 import * as trpcNext from "@trpc/server/adapters/next";
 
-type CreateContextOptions = {};
+/**
+ * Replace this with an object if you want to pass things to createContextInner
+ */
+type CreateContextOptions = Record<string, never>;
 
 /** Use this helper for:
  * - testing, where we dont have to Mock Next.js' req/res

--- a/cli/template/addons/trpc/prisma-context.ts
+++ b/cli/template/addons/trpc/prisma-context.ts
@@ -3,7 +3,10 @@ import * as trpc from "@trpc/server";
 import * as trpcNext from "@trpc/server/adapters/next";
 import { prisma } from "../db/client";
 
-type CreateContextOptions = {};
+/**
+ * Replace this with an object if you want to pass things to createContextInner
+ */
+type CreateContextOptions = Record<string, never>;
 
 /** Use this helper for:
  * - testing, where we dont have to Mock Next.js' req/res


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

As of 5.8.0, build fails when selecting only tRPC or tRPC + Prisma:
```
./src/server/router/context.ts
5:29  Error: Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead.  @typescript-eslint/ban-types
```

This commit fixes this by replacing the `{}` type with `Record<string, never>` and a comment telling users to use an object if they want to pass things.

An alternative would be to relax the eslint rules, but I think keeping them as they are is better.

💯
