### PR TITLE
fix: invalid typeof window comparison to undefined

### DIFF
--- a/.changeset/loud-planets-push.md
+++ b/.changeset/loud-planets-push.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fix invalid typeof window comparison to undefined

--- a/cli/template/page-studs/_app/with-auth-trpc.tsx
+++ b/cli/template/page-studs/_app/with-auth-trpc.tsx
@@ -18,7 +18,7 @@ const MyApp: AppType = ({
 };
 
 const getBaseUrl = () => {
-  if (typeof window !== undefined) return ""; // browser should use relative url
+  if (typeof window !== "undefined") return ""; // browser should use relative url
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // SSR should use vercel url
   return `http://localhost:${process.env.PORT ?? 3000}`; // dev SSR should use localhost
 };

--- a/cli/template/page-studs/_app/with-trpc.tsx
+++ b/cli/template/page-studs/_app/with-trpc.tsx
@@ -10,7 +10,7 @@ const MyApp: AppType = ({ Component, pageProps }) => {
 };
 
 const getBaseUrl = () => {
-  if (typeof window !== undefined) return ""; // browser should use relative url
+  if (typeof window !== "undefined") return ""; // browser should use relative url
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // SSR should use vercel url
   return `http://localhost:${process.env.PORT ?? 3000}`; // dev SSR should use localhost
 };


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The getBaseUrl function was always returning an empty string, i.e. a relative path, because typeof window !== undefined is always true. This PR just changes undefined to the string 'undefined' to fix it.

💯
