### PR TITLE
feat: make links in docs a contrasting color

### DIFF
--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -46,3 +46,6 @@ h5 {
 h5 {
   @apply text-lg;
 }
+.markdown a {
+  @apply text-primary;
+}


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Currently links are the same color as regular text in the docs. This PR changes them to the already defined `color-primary`.

---

## Screenshots

### Before (light and dark)
<img width="723" alt="Screenshot 2022-08-20 at 14 48 20" src="https://user-images.githubusercontent.com/8353666/185747160-93a3b9f6-cfdb-4fd9-8372-ea7da95717fa.png">
<img width="721" alt="Screenshot 2022-08-20 at 14 48 25" src="https://user-images.githubusercontent.com/8353666/185747164-7d84353b-2800-4c0f-8e59-9850193858c9.png">

### After (light and dark)
<img width="719" alt="Screenshot 2022-08-20 at 14 47 40" src="https://user-images.githubusercontent.com/8353666/185747168-8414966b-30d6-4663-a8ad-93ce2472e0bc.png">
<img width="723" alt="Screenshot 2022-08-20 at 14 47 48" src="https://user-images.githubusercontent.com/8353666/185747170-5f447404-1bba-414d-93aa-6a3d985183f6.png">

💯
