### PR TITLE
chore: utils->trpc, inferance and v48

### DIFF
--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -35,11 +35,11 @@ export const dependencyVersionMap = {
   postcss: "^8.4.14",
 
   // tRPC
-  "@trpc/client": "10.0.0-alpha.41",
-  "@trpc/server": "10.0.0-alpha.41",
-  "@trpc/react": "10.0.0-alpha.41",
-  "@trpc/next": "10.0.0-alpha.41",
-  "react-query": "^3.39.2",
+  "@trpc/client": "10.0.0-alpha.48",
+  "@trpc/server": "10.0.0-alpha.48",
+  "@trpc/react": "10.0.0-alpha.48",
+  "@trpc/next": "10.0.0-alpha.48",
+  "@tanstack/react-query": "^4.2.1",
   superjson: "^1.9.1",
 } as const;
 export type AvailableDependencies = keyof typeof dependencyVersionMap;

--- a/cli/src/installers/trpc.ts
+++ b/cli/src/installers/trpc.ts
@@ -8,7 +8,7 @@ export const trpcInstaller: Installer = ({ projectDir, packages }) => {
   addPackageDependency({
     projectDir,
     dependencies: [
-      "react-query",
+      "@tanstack/react-query",
       "superjson",
       "@trpc/server",
       "@trpc/client",
@@ -31,7 +31,7 @@ export const trpcInstaller: Installer = ({ projectDir, packages }) => {
 
   const serverUtilFile = usingAuth ? "auth-server-utils.ts" : "server-utils.ts";
   const serverUtilSrc = path.join(trpcAssetDir, serverUtilFile);
-  const serverUtilDest = path.join(projectDir, "src/server/trpc/utils.ts");
+  const serverUtilDest = path.join(projectDir, "src/server/trpc/trpc.ts");
 
   const contextFile =
     usingAuth && usingPrisma

--- a/cli/template/addons/trpc/auth-index-router.ts
+++ b/cli/template/addons/trpc/auth-index-router.ts
@@ -1,5 +1,5 @@
 // src/server/trpc/router/index.ts
-import { t } from "../utils";
+import { t } from "../trpc";
 import { exampleRouter } from "./example";
 import { authRouter } from "./auth";
 

--- a/cli/template/addons/trpc/auth-router.ts
+++ b/cli/template/addons/trpc/auth-router.ts
@@ -1,4 +1,4 @@
-import { t, authedProcedure } from "../utils";
+import { t, authedProcedure } from "../trpc";
 
 export const authRouter = t.router({
   getSession: t.procedure.query(({ ctx }) => {

--- a/cli/template/addons/trpc/example-prisma-router.ts
+++ b/cli/template/addons/trpc/example-prisma-router.ts
@@ -1,4 +1,4 @@
-import { t } from "../utils";
+import { t } from "../trpc";
 import { z } from "zod";
 
 export const exampleRouter = t.router({

--- a/cli/template/addons/trpc/example-router.ts
+++ b/cli/template/addons/trpc/example-router.ts
@@ -1,4 +1,4 @@
-import { t } from "../utils";
+import { t } from "../trpc";
 import { z } from "zod";
 
 export const exampleRouter = t.router({

--- a/cli/template/addons/trpc/index-router.ts
+++ b/cli/template/addons/trpc/index-router.ts
@@ -1,5 +1,5 @@
 // src/server/router/index.ts
-import { t } from "../utils";
+import { t } from "../trpc";
 
 import { exampleRouter } from "./example";
 

--- a/cli/template/addons/trpc/utils.ts
+++ b/cli/template/addons/trpc/utils.ts
@@ -1,6 +1,5 @@
 // src/utils/trpc.ts
 import { setupTRPC } from "@trpc/next";
-import type { inferProcedureInput, inferProcedureOutput } from "@trpc/server";
 import type { AppRouter } from "../server/trpc/router";
 import superjson from "superjson";
 
@@ -20,23 +19,3 @@ export const trpc = setupTRPC<AppRouter>({
   },
   ssr: false,
 });
-
-/**
- * This is a helper method to infer the output of a query resolver
- * @example type HelloOutput = inferQueryOutput<'hello'>
- */
-export type inferQueryOutput<
-  TRouteKey extends keyof AppRouter["_def"]["queries"],
-> = inferProcedureOutput<AppRouter["_def"]["queries"][TRouteKey]>;
-
-export type inferQueryInput<
-  TRouteKey extends keyof AppRouter["_def"]["queries"],
-> = inferProcedureInput<AppRouter["_def"]["queries"][TRouteKey]>;
-
-export type inferMutationOutput<
-  TRouteKey extends keyof AppRouter["_def"]["mutations"],
-> = inferProcedureOutput<AppRouter["_def"]["mutations"][TRouteKey]>;
-
-export type inferMutationInput<
-  TRouteKey extends keyof AppRouter["_def"]["mutations"],
-> = inferProcedureInput<AppRouter["_def"]["mutations"][TRouteKey]>;


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Updates tRPC to alpha-48. This version supports @tanstack/react-query, so made that change too.

- Renamed the server-utils from `utils` -> `trpc` since that's what the tRPC examples are using.

- Removed inference helpers since they are no longer supported. Check docs for how to do this, (it might change).

---

## Screenshots

_[Screenshots]_

💯
