### PR TITLE
fix: tsconfig include + clean script

### DIFF
--- a/.changeset/six-bikes-tap.md
+++ b/.changeset/six-bikes-tap.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Include `cjs` and `mjs` files in tsconfig. Thanks @timfee for reporting!

--- a/cli/template/base/tsconfig.json
+++ b/cli/template/base/tsconfig.json
@@ -16,12 +16,6 @@
     "incremental": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": [
-    "next-env.d.ts",
-    "next-auth.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "**/*.js"
-  ],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
   "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "start:www": "turbo run start --filter www",
     "dev:cli": "pnpm --filter create-t3-app dev",
     "dev:www": "turbo run dev --filter=www",
+    "clean": "find . -name node_modules -o -name .turbo -o -name dist -o -name build -type d -prune | xargs rm -rf",
     "lint": "eslint . --cache --cache-strategy content",
     "lint:fix": "pnpm lint --fix",
     "format": "prettier --write --plugin-search-dir=. \"**/*.{ts,tsx,md,mdx,json,js,mjs,cjs,astro}\"",


### PR DESCRIPTION
Closes #343 and #342

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Adds `cjs` and `mjs` files to the tsconfig so they can be linted and typechecked.
- Removed explicit including `next-auth.d.ts` since it will be picked up by `**/*.ts` and was confusing for people not choosing NextAuth.js as a package. 
- Also added a clean script for convenience.

---

## Screenshots

_[Screenshots]_

💯
