### PR TITLE
chore: add eol to eslint prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,8 @@
         "case": "camelCase",
         "ignore": ["\\.d\\.ts$", "/^www/i"]
       }
-    ]
+    ],
+    "prettier/prettier": ["error", { "endOfLine": "auto" }]
   },
   "settings": {
     "react": {


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

On Windows, some users were getting problems with prettier formatting:
![image](https://user-images.githubusercontent.com/51714798/186618260-f717efa3-771d-4759-b827-6b1952c53400.png)

See root problem here: https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-delete-cr-prettier-prettier

Fixed this by adding a rule for `endOfLine` in eslintrc

---

## Screenshots

_[Screenshots]_

💯
