### PR TITLE
fix(www): build errors and CI improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://t3.gg/discord
+    about: Ask questions and discuss with other community members

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,8 @@
 "area: cli":
-  - any: ["src/**"]
+  - any: ["cli/src/**"]
 
 "area: t3-app":
-  - any: ["template/**"]
+  - any: ["cli/template/**"]
+
+"documentation":
+  - any: ["www/**", "**/*.md"]

--- a/.github/workflows/PR-CI.yml
+++ b/.github/workflows/PR-CI.yml
@@ -125,3 +125,24 @@ jobs:
       # through. this way it ensures that it is the app's configs that are being used
       - run: cd cli && pnpm start -y ../../ci-test-app
       - run: cd ../ci-test-app && pnpm build
+
+  build-www:
+    runs-on: ubuntu-latest
+    # We explicitely build this in GHA & Vercel since Vercel doesn't seem to catch some errors
+    # meaning the www might be deployed even with errors
+    name: Build www
+    needs: install-deps
+    steps:
+      - uses: actions/checkout@v3
+      - name: Load node_modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7.2.1
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: pnpm build:www

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,7 @@ importers:
       react-dom: ^18.0.0
       react-typist: ^2.0.5
       sass: ^1.54.5
+      svgo: ^2.8.0
     dependencies:
       '@algolia/client-search': 4.14.2
       '@docsearch/css': 3.2.1
@@ -115,6 +116,7 @@ importers:
       preact-render-to-string: 5.2.2_preact@10.10.6
       react-typist: 2.0.5_biqbaboplfbrettd7655fr4n2y
       sass: 1.54.5
+      svgo: 2.8.0
     devDependencies:
       '@astrojs/image': 0.3.6
       '@astrojs/preact': 1.0.2_preact@10.10.6

--- a/www/package.json
+++ b/www/package.json
@@ -22,7 +22,8 @@
     "preact": "^10.7.3",
     "preact-render-to-string": "^5.2.2",
     "react-typist": "^2.0.5",
-    "sass": "^1.54.5"
+    "sass": "^1.54.5",
+    "svgo": "^2.8.0"
   },
   "devDependencies": {
     "@astrojs/image": "^0.3.6",


### PR DESCRIPTION
cc @kroucher 

Fixes build errors when running `pnpm build:www` and added CI check for it.

`www` could be successfully build on Vercel without catching some errors which is sub-optimal.