### PR TITLE
fix: throw error on missing snowpack github token

### DIFF
--- a/www/src/components/blog/avatarList.astro
+++ b/www/src/components/blog/avatarList.astro
@@ -17,8 +17,8 @@ type Commit = {
 
 async function getCommits(url: string) {
   try {
-    const token = import.meta.env.SNOWPACK_PUBLIC_GITHUB_TOKEN ?? "hello";
-    if (!token || token === "hello") {
+    const token = import.meta.env.SNOWPACK_PUBLIC_GITHUB_TOKEN;
+    if (!token) {
       throw new Error(
         'Cannot find "SNOWPACK_PUBLIC_GITHUB_TOKEN" used for escaping rate-limiting.',
       );

--- a/www/src/components/blog/avatarList.astro
+++ b/www/src/components/blog/avatarList.astro
@@ -18,7 +18,7 @@ type Commit = {
 async function getCommits(url: string) {
   try {
     const token = import.meta.env.SNOWPACK_PUBLIC_GITHUB_TOKEN ?? "hello";
-    if (!token) {
+    if (!token || token === "hello") {
       throw new Error(
         'Cannot find "SNOWPACK_PUBLIC_GITHUB_TOKEN" used for escaping rate-limiting.',
       );


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- the code block for throwing an error if the SNOWPACK_PUBLIC_GITHUB_TOKEN is missing was inaccessible because the value is either equal to the token itself or 'hello', both of which pass a null check
- might be related to https://github.com/t3-oss/create-t3-app/pull/372

---

## Screenshots

<img width="695" alt="image" src="https://user-images.githubusercontent.com/8353666/187255833-75965ae5-6fc9-432d-a7e4-cfc9b2fa97c8.png">

💯
