### PR TITLE
feat: add continue and overwrite option on existing dir

### DIFF
--- a/.changeset/seven-pillows-exercise.md
+++ b/.changeset/seven-pillows-exercise.md
@@ -1,0 +1,7 @@
+---
+"create-t3-app": minor
+---
+
+feat: add option to continue and overwrite on existing directory
+
+for reference see: https://github.com/t3-oss/create-t3-app/issues/230

--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -64,6 +64,25 @@ export const scaffoldProject = async ({
         process.exit(0);
       }
 
+      const overwriteAction =
+        overwriteDir === "clear"
+          ? "clear the directory"
+          : "overwrite conflicting files";
+
+      const { confirmOverwriteDir } = await inquirer.prompt<{
+        confirmOverwriteDir: boolean;
+      }>({
+        name: "confirmOverwriteDir",
+        type: "confirm",
+        message: `Are you sure you want to ${overwriteAction}?`,
+        default: false,
+      });
+
+      if (!confirmOverwriteDir) {
+        spinner.fail("Aborting installation...");
+        process.exit(0);
+      }
+
       if (overwriteDir === "clear") {
         spinner.info(
           `Emptying ${chalk.cyan.bold(projectName)} and creating t3 app..\n`,

--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -32,20 +32,35 @@ export const scaffoldProject = async ({
       );
     } else {
       spinner.stopAndPersist();
-      const { overwriteDir } = await inquirer.prompt<{ overwriteDir: boolean }>(
-        {
-          name: "overwriteDir",
-          type: "confirm",
-          message: `${chalk.redBright.bold("Warning:")} ${chalk.cyan.bold(
-            projectName,
-          )} already exists and isn't empty. Do you want to overwrite it?`,
-          default: false,
-        },
-      );
-      if (!overwriteDir) {
+      const { overwriteDir } = await inquirer.prompt<{
+        overwriteDir: "abort" | "clear" | "overwrite";
+      }>({
+        name: "overwriteDir",
+        type: "list",
+        message: `${chalk.redBright.bold("Warning:")} ${chalk.cyan.bold(
+          projectName,
+        )} already exists and isn't empty. How would you like to proceed?`,
+        choices: [
+          { name: "Abort installation", value: "abort", short: "Abort" },
+          {
+            name: "Clear the directory and continue installation",
+            value: "clear",
+            short: "Clear",
+          },
+          {
+            name: "Continue installation and overwrite conflicting files",
+            value: "overwrite",
+            short: "Overwrite",
+          },
+        ],
+        default: "abort",
+      });
+      if (overwriteDir === "abort") {
         spinner.fail("Aborting installation...");
         process.exit(0);
-      } else {
+      }
+
+      if (overwriteDir === "clear") {
         spinner.info(
           `Emptying ${chalk.cyan.bold(projectName)} and creating t3 app..\n`,
         );

--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -41,7 +41,11 @@ export const scaffoldProject = async ({
           projectName,
         )} already exists and isn't empty. How would you like to proceed?`,
         choices: [
-          { name: "Abort installation", value: "abort", short: "Abort" },
+          {
+            name: "Abort installation (recommended)",
+            value: "abort",
+            short: "Abort",
+          },
           {
             name: "Clear the directory and continue installation",
             value: "clear",


### PR DESCRIPTION
Closes https://github.com/t3-oss/create-t3-app/issues/230

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Add another choice to the CLI if there are existing files: continue and overwrite

---

## Screenshots

CLI Option:
<img width="830" alt="Screenshot 2022-08-29 at 21 37 54" src="https://user-images.githubusercontent.com/8353666/187285445-269a9541-a987-4089-b93a-f66c36e747a3.png">

Each choice:
<img width="743" alt="Screenshot 2022-08-29 at 21 37 38" src="https://user-images.githubusercontent.com/8353666/187285859-456c24fb-1968-47bb-9027-ae603662149b.png">
<img width="744" alt="Screenshot 2022-08-29 at 21 38 19" src="https://user-images.githubusercontent.com/8353666/187285843-65325d68-9087-437d-a631-c68cc6f0a99f.png">
<img width="778" alt="Screenshot 2022-08-29 at 21 41 03" src="https://user-images.githubusercontent.com/8353666/187285881-88ee26c6-67e7-4713-b4e0-af94da1cef55.png">

Scaffolding dir before running CLI (and after aborting):
<img width="319" alt="Screenshot 2022-08-29 at 21 40 03" src="https://user-images.githubusercontent.com/8353666/187285968-e0b9e6ca-8a02-4af1-928a-db423c66877e.png">

Scaffolding dir after emptying the folder:
<img width="312" alt="Screenshot 2022-08-29 at 21 41 26" src="https://user-images.githubusercontent.com/8353666/187286554-4b9fe09a-519b-4dfc-95c8-17be16ff13aa.png">


Scaffolding dir after continue and overwriting (package.json is overwritten, `somefile` still exists):
<img width="317" alt="Screenshot 2022-08-29 at 21 40 27" src="https://user-images.githubusercontent.com/8353666/187286568-e3b0d7e9-c997-43ae-90fa-d04bf5cfbe3e.png">

💯