### PR TITLE
docs: update tRPC v10 docs link again

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ yarn create t3-app
 pnpm dlx create-t3-app@latest
 ```
 
-If you prefer using the [experimental v10 version of tRPC](https://alpha.trpc.io/), use `create-t3-app@next`. Note that the alpha versions of tRPC that it uses may contain API changes. We will try our best to keep on top of these, please file an issue if we have missed something.
+If you prefer using the [experimental v10 version of tRPC](https://trpc.io/docs/v10/), use `create-t3-app@next`. Note that the alpha versions of tRPC that it uses may contain API changes. We will try our best to keep on top of these, please file an issue if we have missed something.
 
 An ongoing development branch, `create-t3-app@beta`, can be downloaded for the most recent changes. Expect bugs when using the `beta` branch and please open issues with reproductions when they occur.
 


### PR DESCRIPTION
# Update tRPC v10 docs link again

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The `alpha.` site now redirects to the main site, which by default is the 9.x docs (try in incognito/private window), this change makes it go to the v10 docs

---

💯
