### PR TITLE
fix(template): missing ctx when using ssr with trpc

### DIFF
--- a/.changeset/fast-maps-deliver.md
+++ b/.changeset/fast-maps-deliver.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix(template): missing ctx when using ssr with trpc

--- a/cli/template/page-studs/_app/with-auth-trpc.tsx
+++ b/cli/template/page-studs/_app/with-auth-trpc.tsx
@@ -26,7 +26,7 @@ const getBaseUrl = () => {
 };
 
 export default withTRPC<AppRouter>({
-  config() {
+  config({ ctx }) {
     /**
      * If you want to use SSR, you need to use the server's full URL
      * @link https://trpc.io/docs/ssr

--- a/cli/template/page-studs/_app/with-trpc.tsx
+++ b/cli/template/page-studs/_app/with-trpc.tsx
@@ -18,7 +18,7 @@ const getBaseUrl = () => {
 };
 
 export default withTRPC<AppRouter>({
-  config() {
+  config({ ctx }) {
     /**
      * If you want to use SSR, you need to use the server's full URL
      * @link https://trpc.io/docs/ssr


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Updated withTRPC#config to include the ctx as it is needed to forward the headers when using ssr.

