### PR TITLE
docs: minor improvements

### DIFF
--- a/www/src/components/navigation/TableOfContents.tsx
+++ b/www/src/components/navigation/TableOfContents.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from "react";
 import type { MarkdownHeading } from "astro";
+import { useEffect, useRef, useState } from "react";
 
 type ItemOffsets = {
   id: string;
@@ -52,7 +52,9 @@ export default function TableOfContents({
 
   return (
     <div className="w-full ">
-      <h2 className="text-lg my-4 font-semibold">On this page</h2>
+      <h2 className="text-lg my-4 font-semibold dark:text-white text-slate-900">
+        On this page
+      </h2>
       <ul className="w-full border-l-2 border-t3-purple-300 marker:text-t3-purple-300  dark:border-t3-purple-200 my-1">
         <li
           className={`pl-1 ml-1 marker:bg-t3-purple-300 ${

--- a/www/src/components/navigation/ThemeToggleButton.css
+++ b/www/src/components/navigation/ThemeToggleButton.css
@@ -1,37 +1,26 @@
 .theme-toggle {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.25em;
-	padding: 0.33em 0.67em;
-	border-radius: 99em;
-	
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  padding: 0.33em 0.67em;
+  border-radius: 99em;
 }
 
 .theme-toggle > label:focus-within {
-	outline: 2px solid transparent;
-	box-shadow: 0 0 0 0.08em var(--theme-accent), 0 0 0 0.12em white;
+  outline: 2px solid transparent;
+  box-shadow: 0 0 0 0.08em var(--theme-accent), 0 0 0 0.12em white;
 }
 
 .theme-toggle > label {
-	color: var(--theme-code-inline-text);
-	position: relative;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	opacity: 0.5;
+  color: var(--theme-code-inline-text);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.5;
 }
 
 .theme-toggle .checked {
-	color: var(--theme-accent);
-	opacity: 1;
-}
-
-input[name='theme-toggle'] {
-	position: absolute;
-	opacity: 0;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	z-index: -1;
+  color: var(--theme-accent);
+  opacity: 1;
 }

--- a/www/src/components/navigation/ThemeToggleButton.tsx
+++ b/www/src/components/navigation/ThemeToggleButton.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import "./ThemeToggleButton.css";
 
 const themes = ["light", "dark"];
@@ -73,6 +73,7 @@ export default function ThemeToggleButton() {
           >
             {icon}
             <input
+              className="absolute invisible"
               type="radio"
               name="theme-toggle"
               checked={checked}

--- a/www/src/components/navigation/leftSidebar.astro
+++ b/www/src/components/navigation/leftSidebar.astro
@@ -31,8 +31,8 @@ const sidebar = SIDEBAR[langCode];
             <h2
               class={
                 currentPage === "/"
-                  ? `text-2xl sm:text-xl text-slate-50`
-                  : `text-2xl sm:text-xl dark:text-slate-50 text-slate-900 `
+                  ? `text-2xl sm:text-xl my-2 text-slate-50`
+                  : `text-2xl sm:text-xl my-2 dark:text-slate-50 text-slate-900 `
               }
             >
               {header}

--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -1,6 +1,6 @@
 ---
-import ThemeToggleButton from "./ThemeToggleButton";
 import * as CONFIG from "../../config";
+import ThemeToggleButton from "./ThemeToggleButton";
 
 export interface Props {
   editHref: string;
@@ -13,7 +13,9 @@ const showMoreSection = CONFIG.COMMUNITY_INVITE_URL;
 <div class="flex flex-col w-full items-center sm:items-start pt-8">
   {
     showMoreSection && (
-      <h2 class="heading dark:text-white text-slate-900">More</h2>
+      <h2 class="text-lg mr-4 sm:my-4 sm:mr-0 font-semibold dark:text-white text-slate-900">
+        More
+      </h2>
     )
   }
   <ul>

--- a/www/src/layouts/blog.astro
+++ b/www/src/layouts/blog.astro
@@ -1,13 +1,13 @@
 ---
+import type { MarkdownHeading } from "astro";
+import PageContent from "../components/blog/pageContent.astro";
+import Footer from "../components/footer/footer.astro";
 import HeadCommon from "../components/headCommon.astro";
 import HeadSEO from "../components/headSeo.astro";
-import PageContent from "../components/blog/pageContent.astro";
 import LeftSidebar from "../components/navigation/leftSidebar.astro";
+import Navbar from "../components/navigation/navbar.astro";
 import RightSidebar from "../components/navigation/rightSidebar.astro";
 import * as CONFIG from "../config";
-import type { MarkdownHeading } from "astro";
-import Footer from "../components/footer/footer.astro";
-import Navbar from "../components/navigation/navbar.astro";
 import "../styles/global.css";
 
 export interface Props {
@@ -42,7 +42,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
   <body class="w-full">
     <Navbar mode={"default"} />
     <main
-      class="bg-t3-purple-50 dark:bg-slate-900 w-full justify-items-start place-content-start items-start grid grid-cols-1 sm:grid-cols-6 md:grid-cols-12 h-full relative overflow-y-auto"
+      class="bg-t3-purple-50 dark:bg-slate-900 w-full justify-items-start place-content-start items-start grid grid-cols-1 sm:grid-cols-6 md:grid-cols-12 h-full relative"
     >
       <aside
         id="grid-left"
@@ -63,7 +63,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
       <aside
         id="grid-right"
         title="Table of Contents"
-        class="hidden lg:block pt-1 md:col-start-10 md:col-span-2"
+        class="hidden lg:block pt-1 md:col-start-10 md:col-span-2 sticky top-8"
       >
         <RightSidebar headings={headings} githubEditUrl={githubEditUrl} />
       </aside>


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Wanted to contribute to the new docs and here are some improvements I did. Mostly to do with styling.

- Fixed "On this page" text styles when in light mode
- Added sticky behavior to the sidebars when reading the docs
- Modified "More" text style on right sidebar to be consistent with "On this page" text style
- Added a little more spacing to the headers in left sidebar
- Removed weird behavior where the page would scroll to the top when the user toggled between light theme and dark theme

---

## Screenshots

Since the most important changes are visual, I thought I would share some videos instead. You can also feel free to compare with the Preview URLs from Vercel to try out the improvements.

[Current styles without sticky sidebars and weird scroll theme toggle behavior](https://youtu.be/al6IQWSfVzk)

[New styles with sticky sidebars and improved theme toggle behavior](https://youtu.be/RnE2qQ2OYj8)

💯
