### PR TITLE
feat: better cli text when scaffolding in '.'

### DIFF
--- a/.changeset/spicy-eyes-cry.md
+++ b/.changeset/spicy-eyes-cry.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+feat: better cli text when scaffolding in '.'

--- a/cli/src/helpers/logNextSteps.ts
+++ b/cli/src/helpers/logNextSteps.ts
@@ -12,7 +12,7 @@ export const logNextSteps = ({
   const pkgManager = getUserPkgManager();
 
   logger.info("Next steps:");
-  logger.info(`  cd ${projectName}`);
+  projectName !== "." && logger.info(`  cd ${projectName}`);
   if (noInstall) {
     logger.info(`  ${pkgManager} install`);
   }

--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -103,5 +103,9 @@ export const scaffoldProject = async ({
   if (!noInstall) {
     await execa(`${pkgManager} install`, { cwd: projectDir });
   }
-  spinner.succeed(`${chalk.cyan.bold(projectName)} scaffolded successfully!\n`);
+
+  const scaffoldedName =
+    projectName === "." ? "App" : chalk.cyan.bold(projectName);
+
+  spinner.succeed(`${scaffoldedName} scaffolded successfully!\n`);
 };


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Two small improvements when running the CLI in `.`
- user isn't told to `cd .`
- Say `App scaffolded successfully` instead of `. scaffolded successfully`

Can make the same changes to `next` after this is approved.

---

## Screenshots

Top: scaffolding in another folder

Bottom: scaffolding in `.`

<img width="704" alt="Screenshot 2022-09-15 at 19 51 09" src="https://user-images.githubusercontent.com/8353666/190475964-9e7f8184-5fa3-45b9-bf3f-e3f558d87eac.png">

💯
