### PR TITLE
fix: use correct button text color on website banner

### DIFF
--- a/www/src/components/landingPage/banner.astro
+++ b/www/src/components/landingPage/banner.astro
@@ -42,7 +42,7 @@
                 >
                   <a
                     href="/en/introduction"
-                    class="inline-flex items-center text-white rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer"
+                    class="inline-flex items-center rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer"
                   >
                     <span
                       class="px-3 sm:px-5 py-1.5 text-slate-800 text-sm font-semibold leading-5 bg-t3-purple-100 rounded-full flex items-center justify-between hover:bg-t3-purple-200"
@@ -51,7 +51,7 @@
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         viewBox="0 0 320 512"
-                        class="h-4 ml-2"
+                        class="h-4 ml-2 fill-slate-800"
                       >
                         <path
                           d="M96 480c-8.188 0-16.38-3.125-22.62-9.375c-12.5-12.5-12.5-32.75 0-45.25L242.8 256L73.38 86.63c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0l192 192c12.5 12.5 12.5 32.75 0 45.25l-192 192C112.4 476.9 104.2 480 96 480z"
@@ -63,10 +63,10 @@
                     href="https://github.com/t3-oss/create-t3-app"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="inline-flex items-center text-white rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer bg-white/10 hover:bg-white/20"
+                    class="inline-flex items-center rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer bg-white/10 hover:bg-white/20"
                   >
                     <span
-                      class="ml-1 px-2 py-0.5 text-sm flex items-center justify-between"
+                      class="ml-1 px-2 py-0.5 text-sm flex items-center justify-between text-white"
                     >
                       Github
                       <svg


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Fixed GitHub button text color in the website banner component. It is supposed to be white.

---

## Screenshots

Before
![Bildschirm­foto 2022-09-15 um 21 42 52](https://user-images.githubusercontent.com/61044138/190494691-d040c907-53df-438f-a333-bfec0c33d4af.png)

After
![Bildschirm­foto 2022-09-15 um 22 35 46](https://user-images.githubusercontent.com/61044138/190503754-0d52c48a-ff72-411c-811b-71affcbba719.png)

💯
