### PR TITLE
fix: remove unnecessary underlines in components on landing page

### DIFF
--- a/www/src/components/landingPage/banner.astro
+++ b/www/src/components/landingPage/banner.astro
@@ -42,7 +42,7 @@
                 >
                   <a
                     href="/en/introduction"
-                    class="inline-flex items-center rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer"
+                    class="inline-flex items-center rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer hover:no-underline"
                   >
                     <span
                       class="px-3 sm:px-5 py-1.5 text-slate-800 text-sm font-semibold leading-5 bg-t3-purple-100 rounded-full flex items-center justify-between hover:bg-t3-purple-200"
@@ -63,7 +63,7 @@
                     href="https://github.com/t3-oss/create-t3-app"
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="inline-flex items-center rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer bg-white/10 hover:bg-white/20"
+                    class="inline-flex items-center rounded-full p-1 pr-2 sm:text-base lg:text-sm xl:text-base cursor-pointer bg-white/10 hover:bg-white/20 hover:no-underline"
                   >
                     <span
                       class="ml-1 px-2 py-0.5 text-sm flex items-center justify-between text-white"

--- a/www/src/components/landingPage/community/communityCard.astro
+++ b/www/src/components/landingPage/community/communityCard.astro
@@ -12,7 +12,7 @@ const { text, title, href } = Astro.props;
   href={href}
   target="_blank"
   rel="noopener noreferrer"
-  class="py-8 flex flex-col items-center justify-center rounded-lg p-3 space-y-3 h-60 hover:bg-white/20 bg-white/10 transition-colors cursor-pointer w-full"
+  class="py-8 flex flex-col items-center justify-center rounded-lg p-3 space-y-3 h-60 hover:bg-white/20 bg-white/10 transition-colors cursor-pointer w-full hover:no-underline"
 >
   <div class="w-14 h-14"><slot name="icon" /></div>
   <h2 class="text-xl font-black">{title}</h2>

--- a/www/src/components/landingPage/stack/card.astro
+++ b/www/src/components/landingPage/stack/card.astro
@@ -8,7 +8,11 @@ const { title, href } = Astro.props;
 ---
 
 <div class="relative bg-white/5 rounded-md flex flex-col justify-between">
-  <a href={href} target="_blank" rel="noopener noreferrer"
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="hover:no-underline"
     ><dt
       class="flex space-x-4 items-center bg-white/10 p-2 pl-6 rounded-tr-md rounded-tl-md hover:bg-white/20 transition-colors"
     >


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Some components on the landing page had an underline on hover which looked weird.

---

## Screenshots

Before
![Bildschirm­foto 2022-09-16 um 17 45 50](https://user-images.githubusercontent.com/61044138/190678512-2acf4b71-99cd-488b-96b0-ff8b162e9212.png)

After
![Bildschirm­foto 2022-09-16 um 17 46 12](https://user-images.githubusercontent.com/61044138/190678573-481ee8ad-8e29-4e0d-8c2d-d2d4df87196d.png)