### PR TITLE
fix: docs right sidebar overlaying content

### DIFF
--- a/www/src/components/navigation/TableOfContents.tsx
+++ b/www/src/components/navigation/TableOfContents.tsx
@@ -67,7 +67,7 @@ export default function TableOfContents({ headings = [] }: TOCProps) {
                 className={clsx(
                   "hover:text-t3-purple-700 dark:hover:text-t3-purple-100 text-t3-purple-500 dark:text-t3-purple-200",
                   {
-                    "font-bold text-t3-purple-700 dark:text-t3-purple-100":
+                    "underline text-t3-purple-700 dark:text-t3-purple-100":
                       active === slug,
                     "text-sm": depth > 2,
                   },


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Before, active sidebar table of contents becoming bold made the sidebar resize and sometimes overlay the main content.

This fix uses underline instead. 

---

## Screenshots

Before:

https://user-images.githubusercontent.com/8353666/190897436-b7aa4897-c2d0-49d2-b54d-a1fe7542d38f.mp4

After:

https://user-images.githubusercontent.com/8353666/190897451-3f9a8fa5-3dc3-441c-b71d-a2d1abc82843.mp4


💯
