### PR TITLE
fix: footer background color

### DIFF
--- a/www/src/components/footer/footer.astro
+++ b/www/src/components/footer/footer.astro
@@ -12,8 +12,7 @@ const isLanding = path === "/";
 <footer
   class={clsx("transition-colors mt-auto pb-8 pt-16 flex flex-col", {
     "text-t3-purple-100 bg-[#131232]": isLanding,
-    "text-slate-900 dark:text-t3-purple-100 bg-t3-purple-50 dark:bg-slate-900 ":
-      !isLanding,
+    "text-slate-900 dark:text-t3-purple-100": !isLanding,
   })}
 >
   {isBlog && <AvatarList path={path} />}


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Footer BG was a slightly different color than the remainder of the page in light mode. Actually it doesn't need a bg at all because it can just use that of the page.

---

## Screenshots

Before

<img width="390" alt="Screenshot 2022-09-18 at 12 29 56" src="https://user-images.githubusercontent.com/8353666/190897703-6b48e361-f368-4249-a1ef-fc70c7e3c5ea.png">

After

<img width="389" alt="Screenshot 2022-09-18 at 12 32 45" src="https://user-images.githubusercontent.com/8353666/190897747-44af4783-5f2c-4420-bb63-23991d4d3424.png">

💯
