### PR TITLE
fix: nextauth github missing database field

### DIFF
--- a/.changeset/giant-bugs-argue.md
+++ b/.changeset/giant-bugs-argue.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+GitHub signin requires `refresh_token_expires_in` present in the Account table. Added to the prisma model

--- a/cli/template/addons/prisma/auth-schema.prisma
+++ b/cli/template/addons/prisma/auth-schema.prisma
@@ -26,6 +26,7 @@ model Account {
     provider          String
     providerAccountId String
     refresh_token     String? //@db.Text
+    refresh_token_expires_in Int?
     access_token      String? //@db.Text
     expires_at        Int?
     token_type        String?


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

GitHub sign in requires `refresh_token_expires_in` present in the Account table. 
Added to the `refresh_token_expires_in` Prisma model for Account

---

## Screenshots

<img width="877" alt="CleanShot 2022-09-25 at 12 11 08@2x" src="https://user-images.githubusercontent.com/2830401/192140591-3ade9b73-ddd8-4f98-b65c-e98f36dda603.png">


💯
