### PR TITLE
fix: temp pin next-auth to 4.10 due to peer deps (next)

### DIFF
--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -22,7 +22,7 @@ export type AvailablePackages = typeof availablePackages[number];
  */
 export const dependencyVersionMap = {
   // NextAuth.js
-  "next-auth": "^4.10.2",
+  "next-auth": "~4.10.2",
   "@next-auth/prisma-adapter": "^1.0.4",
 
   // Prisma


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

temporarily pins next-auth to 4.10
this is because 4.11+ has next 12.2.5 as a peer dep, and we are on 12.3.1

💯
