### PR TITLE
fix: terminal font size on small devices

### DIFF
--- a/www/src/components/landingPage/cli.tsx
+++ b/www/src/components/landingPage/cli.tsx
@@ -18,7 +18,7 @@ export default function CodeCard() {
           <Typist.Delay ms={1250} />
         </Typist>
         <Typist
-          className="font-mono leading-1 text-transparent bg-clip-text bg-gradient-to-r text-sm sm:text-xs md:text-sm from-blue-400 via-green-300 to-pink-600"
+          className="font-mono leading-1 text-transparent bg-clip-text bg-gradient-to-r text-[7px] sm:text-xs md:text-sm from-blue-400 via-green-300 to-pink-600"
           cursor={{ show: false }}
           avgTypingDelay={-500}
         >


### PR DESCRIPTION
Fixes the cli font size on small devices.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

The text is pretty small on smartphones now, though. The only alternative I can think of would be to hide the terminal for phone screens smaller than sm.
