### PR TITLE
fix: card link text underline

### DIFF
--- a/www/src/components/landingPage/stack/card.astro
+++ b/www/src/components/landingPage/stack/card.astro
@@ -14,7 +14,7 @@ const { title, href } = Astro.props;
     href={href}
     target="_blank"
     rel="noopener noreferrer"
-    class="hover:no-underline"
+    class="hover:no-underline active:no-underline focus:no-underline"
     ><dt
       class="flex space-x-4 items-center bg-white/10 p-2 pl-5 rounded-tr-md rounded-tl-md hover:bg-white/20 transition-colors"
     >


### PR DESCRIPTION
Removes underlines when a card link has been clicked on.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

