### PR TITLE
fix: typescript docs quote

### DIFF
--- a/www/src/pages/en/usage/typescript.md
+++ b/www/src/pages/en/usage/typescript.md
@@ -6,25 +6,15 @@ layout: ../../../layouts/docs.astro
 
 <blockquote className="w-full max-w-sm relative italic border-l-4 bg-t3-purple-100 dark:text-t3-purple-50 text-slate-900 dark:bg-slate-700 p-2 rounded-md text-sm my-3 border-neutral-500 quote">
   <div className="relative w-fit flex items-center justify-center p-1">
-    <span
-      className="mr-2 hidden sm:block absolute -top-1 left-0 leading-none"
-      aria-hidden="true"
-    >
-      &ldquo;
-    </span>
-    <span
-      className="mr-2 hidden sm:block absolute -right-1 top-7 leading-none"
-      aria-hidden="true"
-    >
-      &ldquo;
-    </span>
-    <p className="mb-4">Build safety nets, not guard rails</p>
+    <p className="mb-4 text-lg md:text-xl">
+      <span aria-hidden="true">&quot;</span>Build safety nets, not guard rails<span aria-hidden="true">&quot;</span>
+    </p>
   </div>
   <cite className="flex items-center justify-end">
     <img
       alt="Avatar of @t3dotgg"
       className="w-12 mr-4 rounded-full bg-neutral-500"
-      src="https://pbs.twimg.com/profile_images/1475643465069301763/FUR05HHs_400x400.jpg"
+      src="https://pbs.twimg.com/profile_images/1570205891001192448/wtV7Iek2_400x400.jpg"
     />
     <div className="flex flex-col items-start">
       <span className="mb-1 text-sm italic font-bold">Theo</span>


### PR DESCRIPTION
Fixes the quote on the typescript docs page

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Screenshots

before
![image](https://user-images.githubusercontent.com/61044138/192619239-95324a5e-1fd8-4c54-967c-17e497049866.png)

after
![image](https://user-images.githubusercontent.com/61044138/192619289-694a9ac4-935a-4a8f-bf6a-0a32901ab75b.png)

