### PR TITLE
feat(cli): tailor env to include relevant keys

### DIFF
--- a/.changeset/little-bears-clap.md
+++ b/.changeset/little-bears-clap.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+tailor env file to include relevant keys

--- a/cli/template/addons/env/auth-prisma.env-example
+++ b/cli/template/addons/env/auth-prisma.env-example
@@ -1,0 +1,14 @@
+# When adding additional env variables, the schema in /env/schema.mjs should be updated accordingly
+
+NODE_ENV=development
+
+# Prisma
+DATABASE_URL=file:./db.sqlite
+
+# Next Auth
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3000
+
+# Next Auth Discord Provider
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=

--- a/cli/template/addons/env/auth.env-example
+++ b/cli/template/addons/env/auth.env-example
@@ -1,0 +1,11 @@
+# When adding additional env variables, the schema in /env/schema.mjs should be updated accordingly
+
+NODE_ENV=development
+
+# Next Auth
+NEXTAUTH_SECRET=
+NEXTAUTH_URL=http://localhost:3000
+
+# Next Auth Discord Provider
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=

--- a/cli/template/addons/env/prisma.env-example
+++ b/cli/template/addons/env/prisma.env-example
@@ -1,3 +1,6 @@
 # When adding additional env variables, the schema in /env/schema.mjs should be updated accordingly
 
 NODE_ENV=development
+
+# Prisma
+DATABASE_URL=file:./db.sqlite


### PR DESCRIPTION
Closes #515

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Copies relevant content into destination `.env `and `.env-example` during `envVars` installer.


## Comment

Added base env variable `NODE_ENV` to give a starting point for the base .env-example 

Was tempted to put the extra `*.env-example` files together with its corresponding `*-schema.mjs` file into separate folders, any thoughts? 

i.e.

Instead of: 
```
├── addons
│   └── env
│       ├── auth-prisma-schema.mjs
│       ├── auth-prisma.env-example
│       ├── ...      
│     
```
It would look something like this
```
├── addons
│   └── env
│       └── auth-prisma
│           ├── schema.mjs
│           └── .env-example
│     
```

💯
