### PR TITLE
docs(contributing): fix typo in changeset commit step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ pnpm changeset
 and filling out the form with the appropriate information. Then, add the generated changeset to git:
 
 ```bash
-git add ./changeset/*.md && git commit -m "chore: add changeset"
+git add .changeset/*.md && git commit -m "chore: add changeset"
 ```
 
 When all that's done, it's time to file a pull request to upstream:


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Fixed wrong path to changeset folder on commit step of contributing

---

## Screenshots
