### PR TITLE
feat: docs footer sticks to bottom and is smaller

### DIFF
--- a/www/src/components/footer/footer.astro
+++ b/www/src/components/footer/footer.astro
@@ -8,15 +8,13 @@ const { path, isBlog } = Astro.props;
 ---
 
 <footer
-  class="transition-colors mt-auto pb-8 pt-16 flex flex-col bg-transparent"
+  class="transition-colors mt-auto pb-8 pt-8 flex flex-col bg-transparent"
 >
   {isBlog && <AvatarList path={path} />}
-  <div
-    class="container px-6 mx-auto space-y-3 divide-y divide-gray-400 md:space-y-12 divide-opacity-50 pt-6"
-  >
+  <div class="container px-6 mx-auto divide-gray-400 divide-opacity-50 pt-6">
     <div class="flex flex-col items-center justify-between w-full">
       <div
-        class="pb-6 mb-6 border border-x-0 border-t-0 border-b-t3-purple-100 sm:border-0"
+        class="pb-2 mb-2 border border-x-0 border-t-0 border-b-t3-purple-100 sm:border-0"
       >
         <a
           href="https://vercel.com/?utm_source=t3-oss&utm_campaign=oss"

--- a/www/src/layouts/docs.astro
+++ b/www/src/layouts/docs.astro
@@ -41,12 +41,14 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
     </title>
   </head>
 
-  <body class="bg-default">
+  <body class="bg-default min-h-screen flex flex-col">
     <JumpToContent />
     <div class="bg-default sticky top-0 w-full max-h-full z-40">
       <Navbar />
     </div>
-    <main class="md:grid md:grid-cols-3 lg:grid-cols-4 md:gap-4 lg:gap-8 mt-10">
+    <main
+      class="flex-1 md:grid md:grid-cols-3 lg:grid-cols-4 md:gap-4 lg:gap-8 mt-10"
+    >
       <aside id="grid-left" title="Site Navigation" class="hidden md:block">
         <div
           class="fixed top-0 pt-16 h-screen md:pt-0 md:h-auto md:sticky md:top-20 z-30 bg-base w-full bg-default overflow-y-auto"


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Previously the footer didn't stick to the bottom in docs pages that are smaller than screen height, now it does
- Also reduced the somewhat ridiculous spacing in it a bit

---

## Screenshots

Before: 
<img width="1485" alt="image" src="https://user-images.githubusercontent.com/8353666/193888055-37183db9-34cb-4537-9e88-0484646cfb0a.png">

After: 
<img width="1485" alt="image" src="https://user-images.githubusercontent.com/8353666/193888009-b1788ab6-d515-4725-a474-c46fc9faef33.png">


💯
