### PR TITLE
fix: two ci action groups (test)

### DIFF
--- a/.github/workflows/ci-labeler.yml
+++ b/.github/workflows/ci-labeler.yml
@@ -2,7 +2,7 @@
 
 # run labeler with elevated permissions before other actions
 
-name: Label Pull Request
+name: Labeler
 
 on:
   pull_request_target:

--- a/.github/workflows/ci-labeler.yml
+++ b/.github/workflows/ci-labeler.yml
@@ -1,0 +1,20 @@
+# this workflow will run on every pr to make sure the project is following the guidelines
+
+# run labeler with elevated permissions before other actions
+name: CI-labeler
+
+on:
+  pull_request_target:
+    branches: ["*"]
+
+  labeler:
+    name: Label PR
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true

--- a/.github/workflows/ci-labeler.yml
+++ b/.github/workflows/ci-labeler.yml
@@ -1,7 +1,7 @@
 # this workflow will run on every pr to make sure the project is following the guidelines
 
 # run labeler with elevated permissions before other actions
-name: CI-labeler
+name: Labeler
 
 on:
   pull_request_target:

--- a/.github/workflows/ci-labeler.yml
+++ b/.github/workflows/ci-labeler.yml
@@ -8,6 +8,7 @@ on:
   pull_request_target:
     branches: ["*"]
 
+jobs:
   labeler:
     name: Label PR
     permissions:

--- a/.github/workflows/ci-labeler.yml
+++ b/.github/workflows/ci-labeler.yml
@@ -1,7 +1,8 @@
 # this workflow will run on every pr to make sure the project is following the guidelines
 
 # run labeler with elevated permissions before other actions
-name: Labeler
+
+name: Label Pull Request
 
 on:
   pull_request_target:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   workflow_run:
-    workflows: [Label PR]
+    workflows: [Labeler]
     types: [completed]
     branches: ["*"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   workflow_run:
-    workflows: [Labeler]
+    workflows: [Label PR]
     types: [completed]
     branches: ["*"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 
 on:
   workflow_run:
-    workflows: [CI-labeler]
+    workflows: [Labeler]
     types: [completed]
     branches: ["*"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,9 @@ name: CI
 
 on:
   workflow_run:
-    workflows: ["CI-labeler"]
+    workflows: [CI-labeler]
+    types: [completed]
     branches: ["*"]
-    types:
-      - completed
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,33 @@
 # this workflow will run on every pr to make sure the project is following the guidelines
 
-name: CI
+# run labeler with elevated permissions before other actions
+name: CI-labeler
 
 on:
-  pull_request:
+  pull_request_target:
     branches: ["*"]
+
+  labeler:
+    name: Label PR
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true
+
+# after labeler, run other actions with strict permissions
+name: CI-main
+
+on:
+  workflow_run:
+    workflows: ["CI-labeler"]
+    branches: ["*"]
+    types: 
+      - completed
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -19,17 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  labeler:
-    name: Label PR
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/labeler@v4
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
+
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,13 @@
 # this workflow will run on every pr to make sure the project is following the guidelines
 
-# run labeler with elevated permissions before other actions
-name: CI-labeler
-
-on:
-  pull_request_target:
-    branches: ["*"]
-
-  labeler:
-    name: Label PR
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/labeler@v4
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
-
 # after labeler, run other actions with strict permissions
-name: CI-main
+name: CI
 
 on:
   workflow_run:
     workflows: ["CI-labeler"]
     branches: ["*"]
-    types: 
+    types:
       - completed
 
 env:
@@ -41,8 +22,6 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

- fix labeler breaking on pr from external branch
- split ci into two action groups

💯
