### PR TITLE
chore: update `updated_at` on pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ Closes #<issue>
 
 ## ✅ Checklist
 
-- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
+- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
 - [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
 - [ ] I performed a functional test on my final commit
 


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-08-15).
- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Updates the date above to today

---

## Screenshots

_[Screenshots]_

💯
