### PR TITLE
feat: remove prettier from base

### DIFF
--- a/.changeset/purple-plums-approve.md
+++ b/.changeset/purple-plums-approve.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+move prettier from base to tailwind installer

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -33,6 +33,7 @@ export const dependencyVersionMap = {
   tailwindcss: "^3.1.6",
   autoprefixer: "^10.4.7",
   postcss: "^8.4.14",
+  prettier: "^2.7.1",
   "prettier-plugin-tailwindcss": "^0.1.13",
 
   // tRPC

--- a/cli/src/installers/tailwind.ts
+++ b/cli/src/installers/tailwind.ts
@@ -11,6 +11,7 @@ export const tailwindInstaller: Installer = ({ projectDir }) => {
       "tailwindcss",
       "postcss",
       "autoprefixer",
+      "prettier",
       "prettier-plugin-tailwindcss",
     ],
     devMode: true,

--- a/cli/template/base/package.json
+++ b/cli/template/base/package.json
@@ -22,7 +22,6 @@
     "@typescript-eslint/parser": "^5.33.0",
     "eslint": "8.22.0",
     "eslint-config-next": "12.3.1",
-    "prettier": "2.7.1",
     "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

No real need to install prettier in the base application - goes against the `you can npm install it` so moved it to the tailwind installer so it's only installed alongside the tailwind-plugin.

---

## Screenshots

_[Screenshots]_

💯
