### PR TITLE
feat: add .env-example

### DIFF
--- a/.changeset/tender-ducks-mate.md
+++ b/.changeset/tender-ducks-mate.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Add .env-example to scaffolded app

--- a/cli/src/installers/envVars.ts
+++ b/cli/src/installers/envVars.ts
@@ -25,6 +25,8 @@ export const envVariablesInstaller: Installer = ({ projectDir, packages }) => {
       break;
   }
 
+  if (!envFile) return;
+
   if (usingPrisma) {
     envContent += `
 # Prisma
@@ -43,13 +45,19 @@ DISCORD_CLIENT_SECRET=
 `;
   }
 
-  if (!envFile) return;
+  const envExampleContent =
+    `# This file will be committed to version control. Make sure not to have any secrets in it.
+# If you are cloning this repo, create a copy of this file named \`.env\` and populate it with the correct information.
+
+` + envContent;
 
   const envSchemaSrc = path.join(envAssetDir, envFile);
   const envSchemaDest = path.join(projectDir, "src/env/schema.mjs");
 
   const envDest = path.join(projectDir, ".env");
+  const envExampleDest = path.join(projectDir, ".env-example");
 
   fs.copySync(envSchemaSrc, envSchemaDest);
   fs.writeFileSync(envDest, envContent, "utf-8");
+  fs.writeFileSync(envExampleDest, envExampleContent, "utf-8");
 };

--- a/cli/src/installers/envVars.ts
+++ b/cli/src/installers/envVars.ts
@@ -46,8 +46,11 @@ DISCORD_CLIENT_SECRET=
   }
 
   const envExampleContent =
-    `# This file will be committed to version control. Make sure not to have any secrets in it.
-# If you are cloning this repo, create a copy of this file named \`.env\` and populate it with the correct information.
+    `# Since .env is gitignored, you can use .env-example to build a new \`.env\` file when you clone the repo.
+# Keep this file up-to-date when you add new variables to \`.env\`.
+
+# This file will be committed to version control, so make sure not to have any secrets in it.
+# If you are cloning this repo, create a copy of this file named \`.env\` and populate it with your secrets.
 
 ` + envContent;
 


### PR DESCRIPTION
Closes #585

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

IIRC we only generated `.env-example` a while ago, and changed it to `.env` so that the app could be immediately started after scaffolding. Will close this PR if anyone has a good reason why we shouldn't include both `.env` and `.env-example` by default.

---

## Changelog

- Creates a `.env-example` file with the same content as the normal `.env` file plus a warning about not putting secrets in there.
- Moves the `if (!envFile) return;` guard clause up a few lines to prevent pointlessly generating the envContent before not saving it to anywhere.

---

## Screenshots

<img width="2672" alt="image" src="https://user-images.githubusercontent.com/8353666/194586769-e04e5ba3-66ed-416b-b862-44a122f72090.png">


💯
