### PR TITLE
fix: remove version lock on nextauth

### DIFF
--- a/.changeset/two-cows-brake.md
+++ b/.changeset/two-cows-brake.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+bump next-auth dependency to ^4.12

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -22,7 +22,7 @@ export type AvailablePackages = typeof availablePackages[number];
  */
 export const dependencyVersionMap = {
   // NextAuth.js
-  "next-auth": "~4.10.2",
+  "next-auth": "^4.12.3",
   "@next-auth/prisma-adapter": "^1.0.4",
 
   // Prisma


### PR DESCRIPTION
Related issue/pr: #504 #505 #506

Removes version lock of next-auth since they no-longer have the strict peerDep of `next@12.2.5`. 

See https://github.com/nextauthjs/next-auth/releases/tag/next-auth%40v4.12.1