### PR TITLE
fix(docs): fix mobile layout issues

### DIFF
--- a/www/src/components/navigation/sidebarToggle.astro
+++ b/www/src/components/navigation/sidebarToggle.astro
@@ -34,10 +34,10 @@ const isLanding = currentPage === "/";
 
 <script is:inline>
   const button = document.querySelector("#sidebar-toggle");
-  const body = document.querySelector("body");
 
   button.addEventListener("click", () => {
-    body.classList.toggle("mobile-sidebar-toggle");
+    // html query selector is already defined in the themeToggleButton script
+    html.classList.toggle("mobile-sidebar-toggle");
     button.toggleAttribute("aria-pressed");
     button.innerHTML =
       button.getAttribute("aria-pressed") === null

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -109,6 +109,7 @@
 
   .mobile-sidebar-toggle {
     overflow: hidden;
+    height: 100vh;
   }
 
   .mobile-sidebar-toggle #grid-left {
@@ -169,7 +170,7 @@
     @apply mt-8 text-sm;
   }
   .markdown table > tbody > tr > td > a {
-    word-wrap: break-word;
+    overflow-wrap: anywhere;
   }
   .markdown table {
     @apply max-w-full table-fixed;


### PR DESCRIPTION
Closes #555

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- change `word-wrap: break-word;` to `overflow-wrap: anywhere` to allow the links in the reference table to wrap by breaking words, stopping them from breaking the layout
- add `height: 100vh;` to `.mobile-sidebar-toggle`, together with the existing `overflow: hidden` property to prevent scrolling when the mobile sidebar is opened
- move the `.mobile-sidebar-toggle` class toggle up from `body` to `html`, to prevent scrolling on the home page when the mobile sidebar is opened
---

## Screenshots
- Both before and after changes images are taken at the bottom of page `/en/deployment/docker`, first without opening the mobile menu then after opening it.

### Before the changes
![image](https://user-images.githubusercontent.com/26082352/194837106-dfc788e1-0c17-4392-bf6e-0757499f3a1a.png)
![image](https://user-images.githubusercontent.com/26082352/194837159-7c3dd97e-9a7b-441e-94db-440d18ddd70c.png)

### After the changes
![image](https://user-images.githubusercontent.com/26082352/194837367-67175ad1-3e51-4ba9-be18-26c0d2806b32.png)
![image](https://user-images.githubusercontent.com/26082352/194837411-fd18da5e-02dc-4d61-aeeb-028433a77d67.png)


💯
