### PR TITLE
docs: top-align table items

### DIFF
--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -175,6 +175,9 @@
   .markdown table {
     @apply max-w-full table-fixed;
   }
+  .markdown table > tbody > tr > td {
+    @apply align-top;
+  }
   .markdown blockquote a {
     @apply text-slate-900 dark:text-t3-purple-50;
   }


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Add `vertical-align: top` to `.markdown table > tbody > tr > td` to align table text on top instead of center.
---

## Screenshots
![image](https://user-images.githubusercontent.com/26082352/194961939-ca4e4a05-084e-4af7-92c8-ac217c01309b.png)

💯
