### PR TITLE
fix: missing characters in homepage cli on android

### DIFF
--- a/www/src/components/headCommon.astro
+++ b/www/src/components/headCommon.astro
@@ -1,5 +1,5 @@
 <!-- Global Metadata -->
-<meta charset="utf-8" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 

--- a/www/src/components/headCommon.astro
+++ b/www/src/components/headCommon.astro
@@ -1,5 +1,5 @@
 <!-- Global Metadata -->
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 

--- a/www/src/components/landingPage/cli.tsx
+++ b/www/src/components/landingPage/cli.tsx
@@ -29,7 +29,7 @@ export default function CodeCard() {
           <br />
           &nbsp;&nbsp;|&nbsp;(__|&nbsp;&nbsp;&nbsp;/&nbsp;_|&nbsp;/&nbsp;/\&nbsp;\|&nbsp;|&nbsp;|&nbsp;_|&nbsp;&nbsp;&nbsp;&nbsp;|&nbsp;|&nbsp;&nbsp;|_&nbsp;\&nbsp;&nbsp;/&nbsp;/\&nbsp;\|&nbsp;&nbsp;_/&nbsp;&nbsp;_/&nbsp;
           <br />
-          &nbsp;&nbsp;&nbsp;\___|_|_\___|_/‾‾\_\_|&nbsp;|___|&nbsp;&nbsp;&nbsp;|_|&nbsp;|___/&nbsp;/_/‾‾\_\_|&nbsp;|_|&nbsp;&nbsp;
+          &nbsp;&nbsp;&nbsp;\___|_|_\___|_/¯¯\_\_|&nbsp;|___|&nbsp;&nbsp;&nbsp;|_|&nbsp;|___/&nbsp;/_/¯¯\_\_|&nbsp;|_|&nbsp;&nbsp;
           <br />
         </Typist>
         <Typist


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Currently, the cli simulation has missing characters on some Android devices (possibly also other OSs?) in the 'A' of the ascii text. This fixes it.

---

## Screenshots

Apologies for the photos, I just borrowed this Android device and don't have anything set up on it

Before:
![IMG_6573 Medium](https://user-images.githubusercontent.com/8353666/196028916-3ee61840-35b1-41a4-bb4c-d9353488bf7d.jpeg)

After:
![IMG_6572 Medium](https://user-images.githubusercontent.com/8353666/196028919-0a633833-16a2-40ed-b0ae-bd990030fab1.jpeg)

💯
