### PR TITLE
fix: rounded corners on technology card

### DIFF
--- a/www/src/components/landingPage/stack/card.astro
+++ b/www/src/components/landingPage/stack/card.astro
@@ -8,15 +8,16 @@ const { title, href } = Astro.props;
 ---
 
 <div
-  class="relative bg-white/5 rounded-md flex flex-col justify-between border border-t3-purple-200/20 hover:border-t3-purple-300/50 transition-colors"
+  class="relative bg-white/5 rounded-md overflow-hidden flex flex-col justify-between border border-t3-purple-200/20 hover:border-t3-purple-300/50 transition-colors"
 >
   <a
     href={href}
     target="_blank"
     rel="noopener noreferrer"
     class="hover:no-underline active:no-underline focus:no-underline"
-    ><div
-      class="flex space-x-4 items-center bg-white/10 p-2 pl-5 rounded-tr-md rounded-tl-md hover:bg-white/20 transition-colors"
+  >
+    <div
+      class="flex space-x-4 items-center bg-white/10 p-2 pl-5 hover:bg-white/20 transition-colors"
     >
       <slot name="icon" />
       <p class="text-lg leading-6 md:text-xl font-medium text-t3-purple-200">


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The technology card was using nested rounded corners which creates an area of a couple of pixels where the background peeks through. I changed the inner div to not have any border-radius, instead using overflow: hidden on the container.

---

## Screenshots

Before
<img width="262" alt="Screenshot 2022-10-18 at 21 01 58" src="https://user-images.githubusercontent.com/8353666/196521817-6e6c7258-5642-4c67-9893-a2c224db4c6b.png">

After
<img width="260" alt="Screenshot 2022-10-18 at 21 05 06" src="https://user-images.githubusercontent.com/8353666/196521823-eef84f0f-072e-4c0c-9486-caaca18cd7f3.png">

💯
