### PR TITLE
fix: use url.original to build og image path

### DIFF
--- a/www/src/components/headSeo.astro
+++ b/www/src/components/headSeo.astro
@@ -15,7 +15,7 @@ const formattedContentTitle = frontmatter
   : SITE.title;
 
 const imageSrc = frontmatter?.image?.src ?? OPEN_GRAPH.image.src;
-const imageUrl = new URL(imageSrc, Astro.url);
+const imageUrl = new URL(imageSrc, Astro.url.origin);
 const imageAlt = frontmatter?.image?.alt ?? OPEN_GRAPH.image.alt;
 
 const ogType = type ?? "article";


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Use `Astro.url.origin` to build the path to OG Image.

