### PR TITLE
fix: og-image working on www/usage/trpc

### DIFF
--- a/.changeset/honest-cooks-learn.md
+++ b/.changeset/honest-cooks-learn.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Headings on docs are now links copied upon click event

--- a/.changeset/pretty-seahorses-cover.md
+++ b/.changeset/pretty-seahorses-cover.md
@@ -1,5 +1,0 @@
----
-"create-t3-app": patch
----
-
-Open graph image fixed on /usage/trpc

--- a/www/src/layouts/docs.astro
+++ b/www/src/layouts/docs.astro
@@ -39,6 +39,37 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
     <title>
       {frontmatter.title} • {CONFIG.SITE.title}
     </title>
+    <script type="module" defer>
+      main();
+      async function main() {
+        const section = document.querySelector("section.w-full");
+
+        const [headings1, headings2, headings3] = [
+          section.querySelectorAll("h1"),
+          section.querySelectorAll("h2"),
+          section.querySelectorAll("h3"),
+        ];
+
+        const headings = [...headings1, ...headings2, ...headings3];
+
+        headings.forEach((heading) => {
+          const link = document.createElement("a");
+          link.href = `#${heading.id}`;
+          link.className = "heading-link";
+          link.innerHTML = heading.innerHTML;
+          heading.innerHTML = "";
+          heading.appendChild(link);
+
+          heading.addEventListener("click", () => {
+            navigator.clipboard.writeText(
+              `${window.location.href}#${heading.id}`,
+            );
+          });
+
+          console.log(heading);
+        });
+      }
+    </script>
   </head>
 
   <body class="bg-default min-h-screen flex flex-col">


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Added a condition to check if the astro props passed is an absolute url or a relative path and handle the og-image accordingly.
_www/src/components/headSeo.astro_ 
---


💯
