### PR TITLE
fix: next-auth doesn't install when using node 18

### DIFF
--- a/.changeset/loud-planets-breathe.md
+++ b/.changeset/loud-planets-breathe.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+get next-auth to work with node 18

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -133,18 +133,6 @@ export const runCli = async () => {
   See: https://github.com/t3-oss/create-t3-app/issues/57`);
   }
 
-  // FIXME: TEMPORARY WARNING WHEN USING NODE 18. SEE ISSUE #59
-  if (process.versions.node.startsWith("18")) {
-    logger.warn(`  WARNING: You are using Node.js version 18. This is currently not compatible with Next-Auth.
-  If you want to use Next-Auth, switch to a previous version of Node, e.g. 16 (LTS).
-  If you have nvm installed, use 'nvm install --lts' to switch to the latest LTS version of Node.
-    `);
-
-    cliResults.packages = cliResults.packages.filter(
-      (val) => val !== "nextAuth",
-    );
-  }
-
   // Needs to be separated outside the if statement to correctly infer the type as string | undefined
   const cliProvidedName = program.args[0];
   if (cliProvidedName) {
@@ -246,11 +234,6 @@ const promptPackages = async (): Promise<AvailablePackages[]> => {
       .map((pkgName) => ({
         name: pkgName,
         checked: false,
-        // FIXME: TEMPORARY WARNING WHEN USING NODE 18. SEE ISSUE #59
-        disabled:
-          pkgName === "nextAuth" && process.versions.node.startsWith("18")
-            ? "Node.js version 18 is currently not compatible with Next-Auth."
-            : false,
       })),
   });
 

--- a/cli/src/helpers/installDependencies.ts
+++ b/cli/src/helpers/installDependencies.ts
@@ -9,7 +9,21 @@ export const installDependencies = async (projectDir: string) => {
   const pkgManager = getUserPkgManager();
   const spinner = ora(`Running ${pkgManager} install...\n`).start();
 
-  await execa(pkgManager, ["install"], { cwd: projectDir });
+  // FIXME: temp fix for next-auth with node 18
+  // see: https://github.com/nextauthjs/next-auth/issues/4575
+  if (process.versions.node.startsWith("18")) {
+    if (pkgManager === "yarn") {
+      await execa(pkgManager, ["add", "--ignore-engines", "true"], {
+        cwd: projectDir,
+      });
+    } else {
+      await execa(pkgManager, ["install", "--engine-strict", "false"], {
+        cwd: projectDir,
+      });
+    }
+  } else {
+    await execa(pkgManager, ["install"], { cwd: projectDir });
+  }
 
   spinner.succeed(chalk.green("Successfully installed dependencies!\n"));
 };

--- a/cli/src/helpers/installDependencies.ts
+++ b/cli/src/helpers/installDependencies.ts
@@ -11,7 +11,10 @@ export const installDependencies = async (projectDir: string) => {
 
   // FIXME: temp fix for next-auth with node 18
   // see: https://github.com/nextauthjs/next-auth/issues/4575
-  if (process.versions.node.startsWith("18")) {
+  if (
+    process.versions.node.startsWith("18") ||
+    process.versions.node.startsWith("19")
+  ) {
     if (pkgManager === "yarn") {
       await execa(pkgManager, ["add", "--ignore-engines", "true"], {
         cwd: projectDir,

--- a/cli/src/installers/nextAuth.ts
+++ b/cli/src/installers/nextAuth.ts
@@ -46,6 +46,15 @@ export const nextAuthInstaller: Installer = ({ projectDir, packages }) => {
     "src/types/next-auth.d.ts",
   );
 
+  // FIXME: temp fix for next-auth with node 18
+  // see: https://github.com/nextauthjs/next-auth/issues/4575
+  const npmrcSrc = path.join(nextAuthAssetDir, "_npmrc");
+  const npmrcDest = path.join(projectDir, ".npmrc");
+  const yarnrcSrc = path.join(nextAuthAssetDir, "_yarnrc");
+  const yarnrcDest = path.join(projectDir, ".yarnrc");
+  fs.copySync(npmrcSrc, npmrcDest);
+  fs.copySync(yarnrcSrc, yarnrcDest);
+
   fs.copySync(apiHandlerSrc, apiHandlerDest);
   fs.copySync(getServerAuthSessionSrc, getServerAuthSessionDest);
   fs.copySync(restrictedApiSrc, restrictedApiDest);

--- a/cli/template/addons/next-auth/_npmrc
+++ b/cli/template/addons/next-auth/_npmrc
@@ -1,0 +1,1 @@
+engine-strict=false

--- a/cli/template/addons/next-auth/_yarnrc
+++ b/cli/template/addons/next-auth/_yarnrc
@@ -1,0 +1,1 @@
+--ignore-engines true


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog
- If the user is on node 18 and chooses to install during cli, `--ignore-engines true` (yarn) or `--engines-strict false` (npm or pnpm) is used
- If next-auth is selected, `.npmrc` and `.yarnrc` files with the same flags are created, regardless of what node version the user is currently on
- FIXME's linking to [the next-auth issue](https://github.com/nextauthjs/next-auth/issues/4575) so that we can hopefully get rid of this again ASAP. I'm also subscribed to the issue.
- Tested with current versions of npm, yarn classic, and pnpm

I don't love doing this and could also see the argument for just leaving next-auth not working on node 18 until they release a fix, but personally I'm leaning towards this (not great) solution for the time being. 

I'd also appreciate a Windows user confirming that this works before we merge.

💯
