### PR TITLE
fix: gh icon arrow to have same color with container border

### DIFF
--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -14,7 +14,7 @@ const githubStars =
 >
   <div
     id="github-stars"
-    class="relative mr-[.33em] hidden md:flex items-center rounded-lg no-underline bg-t3-purple-200/50 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:group-hover:border-t3-purple-200/50 transition-all duration-300 p-1"
+    class="relative mr-[.33em] hidden md:flex items-center bg-clip-padding rounded-lg no-underline border-t3-purple-200/50 bg-t3-purple-200/50 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:group-hover:border-t3-purple-200/50 transition-all duration-300 p-1 after:absolute after:right-[calc(-0.5em-1px)] after:h-0 after:w-0 after:border-8 after:border-r-0 after:border-transparent after:border-l-t3-purple-200/50 after:transition-all after:duration-300 after:group-hover:border-l-t3-purple-200/50 dark:after:border-l-t3-purple-200/20 dark:after:group-hover:border-l-t3-purple-200/50"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -41,10 +41,5 @@ const githubStars =
 <style>
   #github-link:hover {
     text-decoration: none !important;
-  }
-  #github-stars::after {
-    /* make triangle */
-    content: "";
-    @apply absolute -right-[.5em] h-0 w-0 border-8 border-r-0 border-transparent border-l-t3-purple-200/50 transition-all duration-300 group-hover:border-l-t3-purple-200/50 dark:border-l-t3-purple-200/30;
   }
 </style>


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Make the gh icon arrow have consistent color with the container border.

---

## Screenshots

Dark theme:
![image](https://user-images.githubusercontent.com/26082352/197446335-38e1586a-a805-4125-80d1-bb1b2cb316e9.png)

Dark theme hover:
![image](https://user-images.githubusercontent.com/26082352/197446365-fee9522c-a61e-4168-9c99-ea0620492b94.png)

Light theme:
![image](https://user-images.githubusercontent.com/26082352/197446385-7d553a35-860f-4ed6-99cc-ebf0d04e6937.png)

💯
