### PR TITLE
docs: Contribution guidelines gramatical update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ When contributing to `create-t3-app`, whether on GitHub or in other community sp
 
 ### Prerequisites
 
-In order to not waste your time implementing changes that has already been declined, or is generally not needed, start by [opening an issue](https://github.com/t3-oss/create-t3-app/issues/new/choose) describing the problem you would like to solve.
+In order to not waste your time implementing a change that has already been declined, or is generally not needed, start by [opening an issue](https://github.com/t3-oss/create-t3-app/issues/new/choose) describing the problem you would like to solve.
 
 ### Setup your environment
 


### PR DESCRIPTION
Standardize prerequisites verbiage to be singular and not plural.

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Updates `changes` (plural) to `a change` (singular) to match the rest of the Prerequisites paragraph.

---

## Screenshots

💯
