### PR TITLE
docs: add documentation on generating NEXTAUTH_SECRET on generated .env

### DIFF
--- a/.changeset/pretty-shrimps-behave.md
+++ b/.changeset/pretty-shrimps-behave.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Add documentation on how to generate NEXTAUTH_SECRET in .env file for clarity

--- a/cli/src/installers/envVars.ts
+++ b/cli/src/installers/envVars.ts
@@ -36,6 +36,8 @@ DATABASE_URL=file:./db.sqlite
   if (usingAuth) {
     envContent += `
 # Next Auth
+# You can generate the secret via 'openssl rand -base64 32' on Linux
+# More info: https://next-auth.js.org/configuration/options#secret
 NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3000
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Adds a short comment on .env to document some ways to generate NEXTAUTH_SECRET and a short reference to related link in Next-Auth docs.

---

## Screenshots

_[Screenshots]_

💯
