### PR TITLE
feat: AuthShowcase only makes query when logged in

### DIFF
--- a/.changeset/unlucky-clocks-report.md
+++ b/.changeset/unlucky-clocks-report.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+only try to get secret message if there is a user

--- a/cli/template/page-studs/index/with-auth-trpc-tw.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc-tw.tsx
@@ -64,9 +64,12 @@ const Home: NextPage = () => {
 export default Home;
 
 const AuthShowcase: React.FC = () => {
-  const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery();
-
   const { data: sessionData } = useSession();
+
+  const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
+    undefined,
+    { enabled: sessionData?.user !== undefined },
+  );
 
   return (
     <div className="flex flex-col items-center justify-center gap-2">

--- a/cli/template/page-studs/index/with-auth-trpc-tw.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc-tw.tsx
@@ -67,7 +67,7 @@ const AuthShowcase: React.FC = () => {
   const { data: sessionData } = useSession();
 
   const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
-    undefined,
+    undefined, // no input
     { enabled: sessionData?.user !== undefined },
   );
 

--- a/cli/template/page-studs/index/with-auth-trpc.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc.tsx
@@ -72,7 +72,7 @@ const AuthShowcase: React.FC = () => {
   const { data: sessionData } = useSession();
 
   const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
-    undefined,
+    undefined, // no input
     { enabled: sessionData?.user !== undefined },
   );
 

--- a/cli/template/page-studs/index/with-auth-trpc.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc.tsx
@@ -69,9 +69,12 @@ const Home: NextPage = () => {
 export default Home;
 
 const AuthShowcase: React.FC = () => {
-  const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery();
-
   const { data: sessionData } = useSession();
+
+  const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
+    undefined,
+    { enabled: sessionData?.user !== undefined },
+  );
 
   return (
     <div className={styles.authShowcase}>


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

A lot of people seem to be confused that there are tRPC errors in the console as soon as they open their app

Example (there have been a bunch of these): https://discord.com/channels/966627436387266600/1020552951116333217/threads/1030282705734226051

This avoids those errors by only enabling the query if there is a user. As a nice benefit it also acts as builtin documentation for passing `undefined` for the input and using the `enabled` option.

---

## Screenshots

(taken after starting the dev server and navigating to localhost:3000 without being logged in)

Before:
<img width="762" alt="Screenshot 2022-11-02 at 21 24 57" src="https://user-images.githubusercontent.com/8353666/199598237-6c648e21-97be-48cb-a310-d11a4e5c42ed.png">

After:
<img width="762" alt="Screenshot 2022-11-02 at 21 24 16" src="https://user-images.githubusercontent.com/8353666/199598253-fcc7aae7-9818-4a63-9952-fe24ae80b7e2.png">

💯
