### PR TITLE
refactor: consistent use of React.FC

### DIFF
--- a/cli/template/base/src/pages/index.tsx
+++ b/cli/template/base/src/pages/index.tsx
@@ -65,11 +65,11 @@ type TechnologyCardProps = {
   documentation: string;
 };
 
-const TechnologyCard = ({
+const TechnologyCard: React.FC<TechnologyCardProps> = ({
   name,
   description,
   documentation,
-}: TechnologyCardProps) => {
+}) => {
   return (
     <section className={styles.card}>
       <h2 className={styles.cardTitle}>{name}</h2>

--- a/cli/template/page-studs/index/with-auth-trpc-tw.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc-tw.tsx
@@ -68,7 +68,7 @@ const AuthShowcase: React.FC = () => {
 
   const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
     undefined, // no input
-    { enabled: sessionData?.user !== undefined }
+    { enabled: sessionData?.user !== undefined },
   );
 
   return (

--- a/cli/template/page-studs/index/with-auth-trpc-tw.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc-tw.tsx
@@ -68,7 +68,7 @@ const AuthShowcase: React.FC = () => {
 
   const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
     undefined, // no input
-    { enabled: sessionData?.user !== undefined },
+    { enabled: sessionData?.user !== undefined }
   );
 
   return (
@@ -97,11 +97,11 @@ type TechnologyCardProps = {
   documentation: string;
 };
 
-const TechnologyCard = ({
+const TechnologyCard: React.FC<TechnologyCardProps> = ({
   name,
   description,
   documentation,
-}: TechnologyCardProps) => {
+}) => {
   return (
     <section className="flex flex-col justify-center rounded border-2 border-gray-500 p-6 shadow-xl duration-500 motion-safe:hover:scale-105">
       <h2 className="text-lg text-gray-700">{name}</h2>

--- a/cli/template/page-studs/index/with-auth-trpc.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc.tsx
@@ -73,7 +73,7 @@ const AuthShowcase: React.FC = () => {
 
   const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
     undefined, // no input
-    { enabled: sessionData?.user !== undefined },
+    { enabled: sessionData?.user !== undefined }
   );
 
   return (
@@ -96,11 +96,11 @@ type TechnologyCardProps = {
   documentation: string;
 };
 
-const TechnologyCard = ({
+const TechnologyCard: React.FC<TechnologyCardProps> = ({
   name,
   description,
   documentation,
-}: TechnologyCardProps) => {
+}) => {
   return (
     <section className={styles.card}>
       <h2 className={styles.cardTitle}>{name}</h2>

--- a/cli/template/page-studs/index/with-auth-trpc.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc.tsx
@@ -73,7 +73,7 @@ const AuthShowcase: React.FC = () => {
 
   const { data: secretMessage } = trpc.auth.getSecretMessage.useQuery(
     undefined, // no input
-    { enabled: sessionData?.user !== undefined }
+    { enabled: sessionData?.user !== undefined },
   );
 
   return (

--- a/cli/template/page-studs/index/with-trpc-tw.tsx
+++ b/cli/template/page-studs/index/with-trpc-tw.tsx
@@ -68,11 +68,11 @@ type TechnologyCardProps = {
   documentation: string;
 };
 
-const TechnologyCard = ({
+const TechnologyCard: React.FC<TechnologyCardProps> = ({
   name,
   description,
   documentation,
-}: TechnologyCardProps) => {
+}) => {
   return (
     <section className="flex flex-col justify-center rounded border-2 border-gray-500 p-6 shadow-xl duration-500 motion-safe:hover:scale-105">
       <h2 className="text-lg text-gray-700">{name}</h2>

--- a/cli/template/page-studs/index/with-trpc.tsx
+++ b/cli/template/page-studs/index/with-trpc.tsx
@@ -73,11 +73,11 @@ type TechnologyCardProps = {
   documentation: string;
 };
 
-const TechnologyCard = ({
+const TechnologyCard: React.FC<TechnologyCardProps> = ({
   name,
   description,
   documentation,
-}: TechnologyCardProps) => {
+}) => {
   return (
     <section className={styles.card}>
       <h2 className={styles.cardTitle}>{name}</h2>

--- a/cli/template/page-studs/index/with-tw.tsx
+++ b/cli/template/page-studs/index/with-tw.tsx
@@ -61,11 +61,11 @@ type TechnologyCardProps = {
   documentation: string;
 };
 
-const TechnologyCard = ({
+const TechnologyCard: React.FC<TechnologyCardProps> = ({
   name,
   description,
   documentation,
-}: TechnologyCardProps) => {
+}) => {
   return (
     <section className="flex flex-col justify-center rounded border-2 border-gray-500 p-6 shadow-xl duration-500 motion-safe:hover:scale-105">
       <h2 className="text-lg text-gray-700">{name}</h2>


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

When selecting NextAuth the boilerplate uses React.FC on the AuthShowcase component

```typescript
const AuthShowcase: React.FC = () => {
  ...
}
```

But the TechnologyCard component doesn't.

---

💯
