### PR TITLE
fix: landing page background image max width

### DIFF
--- a/www/src/layouts/landingPage.astro
+++ b/www/src/layouts/landingPage.astro
@@ -26,7 +26,7 @@ const currentPage = Astro.url.pathname;
     <JumpToContent />
     <img
       src="/images/background-pattern.svg"
-      class="absolute inset-0 opacity-5 h-max w-max object-cover"
+      class="absolute inset-0 opacity-5 h-max w-max min-w-full object-cover"
       alt="background pattern"
     />
     <div class="relative">


### PR DESCRIPTION
Closes #677

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Fixes the screen being wider than the background image.

---

## Screenshots

Here's what happens: (I removed the reduced opacity so it's clearer to see the issue)

<img width="1383" alt="image" src="https://user-images.githubusercontent.com/6522773/199995019-ddd9f254-15a4-4244-afe6-63acf22a378f.png">


💯
