### PR TITLE
fix(cli): fix create-t3-app to use yarn default behavior (#678)

### DIFF
--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -258,21 +258,29 @@ const promptGit = async (): Promise<boolean> => {
 };
 
 const promptInstall = async (): Promise<boolean> => {
-  const packageManager = getUserPkgManager();
+  const pkgManager = getUserPkgManager();
 
   const { install } = await inquirer.prompt<{ install: boolean }>({
     name: "install",
     type: "confirm",
-    message: `Would you like us to run '${packageManager} install'?`,
+    message:
+      `Would you like us to run '${pkgManager}` +
+      (pkgManager === "yarn" ? `'?` : ` install'?`),
     default: true,
   });
 
   if (install) {
     logger.success("Alright. We'll install the dependencies for you!");
   } else {
-    logger.info(
-      `No worries. You can run '${packageManager} install' later to install the dependencies.`,
-    );
+    if (pkgManager === "yarn") {
+      logger.info(
+        `No worries. You can run '${pkgManager}' later to install the dependencies.`,
+      );
+    } else {
+      logger.info(
+        `No worries. You can run '${pkgManager} install' later to install the dependencies.`,
+      );
+    }
   }
 
   return install;

--- a/cli/src/helpers/installDependencies.ts
+++ b/cli/src/helpers/installDependencies.ts
@@ -13,7 +13,7 @@ export const installDependencies = async ({ projectDir }: Options) => {
   const pkgManager = getUserPkgManager();
   const spinner =
     pkgManager === "yarn"
-      ? ora(`Running ${pkgManager}\n`).start()
+      ? ora("Running yarn...\n").start()
       : ora(`Running ${pkgManager} install...\n`).start();
 
   // If the package manager is yarn, use yarn's default behavior to install dependencies

--- a/cli/src/helpers/installDependencies.ts
+++ b/cli/src/helpers/installDependencies.ts
@@ -11,9 +11,17 @@ type Options = {
 export const installDependencies = async ({ projectDir }: Options) => {
   logger.info("Installing dependencies...");
   const pkgManager = getUserPkgManager();
-  const spinner = ora(`Running ${pkgManager} install...\n`).start();
+  const spinner =
+    pkgManager === "yarn"
+      ? ora(`Running ${pkgManager}\n`).start()
+      : ora(`Running ${pkgManager} install...\n`).start();
 
-  await execa(pkgManager, ["install"], { cwd: projectDir });
+  // If the package manager is yarn, use yarn's default behavior to install dependencies
+  if (pkgManager === "yarn") {
+    await execa(pkgManager, [], { cwd: projectDir });
+  } else {
+    await execa(pkgManager, ["install"], { cwd: projectDir });
+  }
 
   spinner.succeed(chalk.green("Successfully installed dependencies!\n"));
 };

--- a/cli/src/helpers/logNextSteps.ts
+++ b/cli/src/helpers/logNextSteps.ts
@@ -14,7 +14,12 @@ export const logNextSteps = ({
   logger.info("Next steps:");
   projectName !== "." && logger.info(`  cd ${projectName}`);
   if (noInstall) {
-    logger.info(`  ${pkgManager} install`);
+    // To reflect yarn's default behavior of installing packages when no additional args provided
+    if (pkgManager === "yarn") {
+      logger.info(`  ${pkgManager}`);
+    } else {
+      logger.info(`  ${pkgManager} install`);
+    }
   }
 
   if (packages?.prisma.inUse) {


### PR DESCRIPTION
updated variable naming for consistency; moved changes from #681 to this one due to issues with my local repo desyncing

Closes #678 

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

--- Fixed yarn to use default behavior when invoking `yarn`, which is to install dependencies
--- Updated the output of the CLI to reflect the differences in the package manager commands of yarn and not-yarn to better inform the user

## Screenshots

**pnpm install**
![image](https://user-images.githubusercontent.com/28771786/200126372-ff91b9d2-c4fc-4bd1-a0d0-ea339d85a20e.png)

**yarn start with user wanting to run yarn**
![image](https://user-images.githubusercontent.com/28771786/200126402-75a21dec-113a-451c-aecd-e58e66cf379b.png)

**yarn start with user not wanting to run yarn through cli**
![image](https://user-images.githubusercontent.com/28771786/200126427-952870e3-711e-47bb-bea1-84a3b0c74be4.png)

💯
