### PR TITLE
fix(docs): fixed list styling issue on sm/md screens.

### DIFF
--- a/.changeset/seven-eggs-vanish.md
+++ b/.changeset/seven-eggs-vanish.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Issue #692 fix

--- a/.changeset/seven-eggs-vanish.md
+++ b/.changeset/seven-eggs-vanish.md
@@ -1,5 +1,0 @@
----
-"create-t3-app": patch
----
-
-Issue #692 fix

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -136,7 +136,7 @@
     @apply mt-8 mb-0 text-xl font-semibold;
   }
   .markdown li {
-    @apply list-disc;
+    @apply list-disc break-all lg:break-normal;
   }
   .markdown ol > li {
     @apply list-decimal;


### PR DESCRIPTION
Closes #692

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The word break on list elements was set to 'normal' so on small and medium devices docs body was wider then nav. 
Now the word-break stays the same on large screens but on small and medium its set to `break-all`

---

## Screenshots

Before:
<img width="359" alt="Before" src="https://user-images.githubusercontent.com/34962307/200162255-00bdbcd1-4599-4e20-af36-8910bab9663d.png">

Now: 
<img width="359" alt="After" src="https://user-images.githubusercontent.com/34962307/200162274-ee48fb55-1de5-4015-ad54-fe8695e27855.png">

💯
