### PR TITLE
fix(docs): consistent use of `NextAuth` / `NextAuth.js`

### DIFF
--- a/www/src/pages/en/faq.md
+++ b/www/src/pages/en/faq.md
@@ -13,7 +13,7 @@ We try to keep this project as simple as possible, so you can start with just th
 If you are not familiar with the different technologies used in this project, please refer to the respective docs. If you still are in the wind, please join our [Discord](https://t3.gg/discord) and ask for help.
 
 - [Next.js](https://nextjs.org/)
-- [Next-Auth.js](https://next-auth.js.org)
+- [NextAuth.js](https://next-auth.js.org)
 - [Prisma](https://prisma.io)
 - [TailwindCSS](https://tailwindcss.com)
 - [tRPC](https://trpc.io)

--- a/www/src/pages/en/installation.md
+++ b/www/src/pages/en/installation.md
@@ -42,7 +42,7 @@ For our CI, we have some experimental flags that allow you to scaffold any app w
 | `--CI`       | Let the CLI know you're in CI mode  |
 | `--trpc`     | Include tRPC in the project         |
 | `--prisma`   | Include Prisma in the project       |
-| `--nextAuth` | Include Next-Auth.js in the project |
+| `--nextAuth` | Include NextAuth.js in the project  |
 | `--tailwind` | Include Tailwind CSS in the project |
 
 **Note: If you don't provide the `CI` flag, the rest of these flags has no effect.**

--- a/www/src/pages/en/usage/next-auth.md
+++ b/www/src/pages/en/usage/next-auth.md
@@ -130,7 +130,7 @@ const userRouter = router({
 
 ## Usage with Prisma
 
-Getting Next-Auth.js to work with Prisma requires a lot of [initial setup](https://next-auth.js.org/adapters/models/). `create-t3-app` handles all of this for you, and if you select both Prisma and NextAuth.js, you'll get a fully working authentication system with all the required models preconfigured. We ship your scaffolded app with a preconfigured Discord OAuth provider, which we chose because it is one of the easiest to get started with - just provide your tokens in the `.env` and you're good to go. However, you can easily add more providers by following the [NextAuth.js docs](https://next-auth.js.org/providers/). Note that certain providers require extra fields to be added to certain models. We recommend you read the documentation for the provider you would like to use to make sure you have all the required fields.
+Getting NextAuth.js to work with Prisma requires a lot of [initial setup](https://next-auth.js.org/adapters/models/). `create-t3-app` handles all of this for you, and if you select both Prisma and NextAuth.js, you'll get a fully working authentication system with all the required models preconfigured. We ship your scaffolded app with a preconfigured Discord OAuth provider, which we chose because it is one of the easiest to get started with - just provide your tokens in the `.env` and you're good to go. However, you can easily add more providers by following the [NextAuth.js docs](https://next-auth.js.org/providers/). Note that certain providers require extra fields to be added to certain models. We recommend you read the documentation for the provider you would like to use to make sure you have all the required fields.
 
 ### Adding new fields to your models
 

--- a/www/src/pages/en/usage/next-auth.md
+++ b/www/src/pages/en/usage/next-auth.md
@@ -1,6 +1,6 @@
 ---
 title: NextAuth.js
-description: Usage of NextAuth
+description: Usage of NextAuth.js
 layout: ../../../layouts/docs.astro
 ---
 
@@ -35,7 +35,7 @@ const User = () => {
 
 ## Inclusion of `user.id` on the Session
 
-`create-t3-app` is configured to utilise the [session callback](https://next-auth.js.org/configuration/callbacks#session-callback) in the NextAuth config to include the user's ID within the `session` object.
+`create-t3-app` is configured to utilise the [session callback](https://next-auth.js.org/configuration/callbacks#session-callback) in the NextAuth.js config to include the user's ID within the `session` object.
 
 ```ts:pages/api/auth/[...nextauth].ts
 callbacks: {
@@ -169,6 +169,6 @@ Usage of NextAuth.js with Next.js middleware [requires the use of the JWT sessio
 
 | Resource                          | Link                                    |
 | --------------------------------- | --------------------------------------- |
-| NextAuth Docs                     | https://next-auth.js.org/               |
-| NextAuth GitHub                   | https://github.com/nextauthjs/next-auth |
+| NextAuth.js Docs                  | https://next-auth.js.org/               |
+| NextAuth.js GitHub                | https://github.com/nextauthjs/next-auth |
 | tRPC Kitchen Sink - with NextAuth | https://kitchen-sink.trpc.io/next-auth  |


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Replace all `Next-Auth` with `NextAuth`
- Replace all `Next-Auth.js` with `NextAuth.js`

Why omit the `-`? PFB.

![PRimage](https://user-images.githubusercontent.com/89210438/200570704-498d225e-42fb-4f1a-816e-381c51ec8236.png)


---

💯
