### PR TITLE
docs: increase the contrast of navigation links' text color against the background color.

### DIFF
--- a/www/src/components/navigation/leftSidebar.astro
+++ b/www/src/components/navigation/leftSidebar.astro
@@ -53,7 +53,7 @@ const sidebar = SIDEBAR[langCode];
                         href={url}
                         aria-current={isActive ? "page" : false}
                         class={clsx(
-                          "block border-l-2 py-2 pl-4 text-lg text-t3-purple-400 transition-colors hover:border-t3-purple-300/50 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100",
+                          "block border-l-2 py-2 pl-4 text-lg text-t3-purple-800 transition-colors hover:border-t3-purple-300/50 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100",
                           {
                             "font-medium": isActive,
                             "border-t3-purple-300": isActive,

--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -42,7 +42,7 @@ const { editHref } = Astro.props;
     </li>
 
     <li
-      class="hover:text-t3-purple-500 dark:hover:text-t3-purple-100 text-t3-purple-800 dark:text-t3-purple-200"
+      class="hover:text-t3-purple-400 dark:hover:text-t3-purple-100 text-t3-purple-800 dark:text-t3-purple-200"
     >
       <a
         class="flex items-center gap-2"

--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -17,7 +17,7 @@ const { editHref } = Astro.props;
 
   <ul class="flex md:block items-center flex-col">
     <li
-      class="hidden lg:block hover:text-t3-purple-700 dark:hover:text-t3-purple-100 text-t3-purple-500 dark:text-t3-purple-200"
+      class="hidden lg:block hover:text-t3-purple-400 dark:hover:text-t3-purple-100 text-t3-purple-800 dark:text-t3-purple-200"
     >
       <a class="flex items-center gap-2" href={editHref} target="_blank">
         <svg
@@ -42,7 +42,7 @@ const { editHref } = Astro.props;
     </li>
 
     <li
-      class="hover:text-t3-purple-700 dark:hover:text-t3-purple-100 text-t3-purple-500 dark:text-t3-purple-200"
+      class="hover:text-t3-purple-500 dark:hover:text-t3-purple-100 text-t3-purple-800 dark:text-t3-purple-200"
     >
       <a
         class="flex items-center gap-2"

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -63,7 +63,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
                     navbarLink.href === currentPage,
                   "rounded-lg text-t3-purple-100 hover:bg-t3-purple-200/10 hover:text-t3-purple-300":
                     isLanding,
-                  "rounded-lg text-t3-purple-500 hover:bg-t3-purple-200/30 hover:text-t3-purple-800 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
+                  "rounded-lg text-t3-purple-800 hover:bg-t3-purple-200/30 hover:text-t3-purple-500 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
                     !isLanding,
                 },
               )}

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -63,7 +63,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
                     navbarLink.href === currentPage,
                   "rounded-lg text-t3-purple-100 hover:bg-t3-purple-200/10 hover:text-t3-purple-300":
                     isLanding,
-                  "rounded-lg text-t3-purple-500 hover:bg-t3-purple-200/30 hover:text-t3-purple-400 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
+                  "rounded-lg text-t3-purple-500 hover:bg-t3-purple-200/30 hover:text-t3-purple-800 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
                     !isLanding,
                 },
               )}

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -63,7 +63,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
                     navbarLink.href === currentPage,
                   "rounded-lg text-t3-purple-100 hover:bg-t3-purple-200/10 hover:text-t3-purple-300":
                     isLanding,
-                  "rounded-lg text-t3-purple-800 hover:bg-t3-purple-200/30 hover:text-t3-purple-500 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
+                  "rounded-lg text-t3-purple-800 hover:bg-t3-purple-200/30 hover:text-t3-purple-400 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
                     !isLanding,
                 },
               )}

--- a/www/src/components/navigation/tableOfContents.astro
+++ b/www/src/components/navigation/tableOfContents.astro
@@ -31,7 +31,7 @@ headings = [{ depth: 2, slug: "overview", text: title }, ...headings].filter(
             } w-full list-none border-l-2 border-t3-purple-300/20 pb-1 transition-all duration-300 hover:border-t3-purple-300/50`}
           >
             <a
-              class="text-t3-purple-500 hover:text-t3-purple-700 dark:text-t3-purple-200 dark:hover:text-t3-purple-100"
+              class="text-t3-purple-800 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100"
               href={`#${slug}`}
             >
               {text}


### PR DESCRIPTION
Closes #720

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

* Updated the text color of the left navigation links from `text-t3-purple-400` to `text-t3-purple-800`. 
* Updated the text color of the top navigation links from `text-t3-purple-500` to `text-t3-purple-800` and its `:hover` pseudo-class from `hover:text-t3-purple-800` to `hover:text-t3-purple-400`. This is just for consistency. 
* Updated the text color of `Table of Contents` from `text-t3-purple-500` to `text-t3-purple-800` and its `:hover` pseudo-class from `hover:text-t3-purple-800` to `hover:text-t3-purple-400`.
* Updated the text color of `More` from `text-t3-purple-500` to `text-t3-purple-800` and its `:hover` pseudo-class from `hover:text-t3-purple-800` to `hover:text-t3-purple-400`.

---

## Screenshots

Before:
![Screen Shot 2022-11-11 at 10 03 22 PM](https://user-images.githubusercontent.com/19621827/201456484-3859a5b9-649e-44f8-b283-98d6440fb50d.png)

After:
![Screen Shot 2022-11-11 at 10 22 47 PM](https://user-images.githubusercontent.com/19621827/201456836-ae377835-5ba4-47f7-bdd9-cb500bc9df72.png)


💯
