### PR TITLE
docs: bug - firefox doesn't always use custom scrollbars

### DIFF
--- a/www/src/components/navigation/leftSidebar.astro
+++ b/www/src/components/navigation/leftSidebar.astro
@@ -22,9 +22,7 @@ const sidebar = SIDEBAR[langCode];
 <div class="w-full ml--40 md:ml-0 mb-6 mx-auto px-6 md:px-8 md:hidden">
   <Search isLanding={isLanding} client:idle />
 </div>
-<div
-  class="w-full h-full bg-default transition-colors duration-300"
->
+<div class="w-full h-full bg-default transition-colors duration-300">
   <ul class="pb-28 pr-4 pl-4 md:pb-0 dark:text-t3-purple-50 text-slate-900">
     {
       Object.entries(sidebar).map(([header, children]) => (

--- a/www/src/components/navigation/leftSidebar.astro
+++ b/www/src/components/navigation/leftSidebar.astro
@@ -23,7 +23,7 @@ const sidebar = SIDEBAR[langCode];
   <Search isLanding={isLanding} client:idle />
 </div>
 <div
-  class="t3-scrollbar w-full h-full bg-default transition-colors duration-300"
+  class="w-full h-full bg-default transition-colors duration-300"
 >
   <ul class="pb-28 pr-4 pl-4 md:pb-0 dark:text-t3-purple-50 text-slate-900">
     {

--- a/www/src/layouts/docs.astro
+++ b/www/src/layouts/docs.astro
@@ -80,7 +80,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
       <nav
         id="grid-left"
         title="Site Navigation"
-        class="bg-default t3-scrollbar hidden md:flex flex-col justify-start sticky col-span-1 w-full h-auto max-h-[calc(100vh-80px)] md:max-h-[calc(100vh-96px)] top-20 pt-4 md:pt-0 md:top-24 transition-colors duration-300"
+        class="bg-default t3-scrollbar hidden md:flex flex-col justify-start sticky col-span-1 w-full h-auto max-h-[calc(100vh-80px)] md:max-h-[calc(100vh-96px)] top-20 pt-4 md:pt-0 md:top-24 transition-colors duration-300 overflow-y-auto"
       >
         <LeftSidebar currentPage={currentPage} />
       </nav>
@@ -97,7 +97,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
       <aside
         id="grid-right"
         title="Table of Contents"
-        class="t3-scrollbar hidden lg:flex lg:flex-col lg:justify-start sticky col-span-1 w-full h-auto max-h-[calc(100vh-100px)] pr-4 top-[100px]"
+        class="t3-scrollbar hidden lg:flex lg:flex-col lg:justify-start sticky col-span-1 w-full h-auto max-h-[calc(100vh-100px)] pr-4 pb-4 top-[100px] overflow-y-auto"
       >
         <RightSidebar
           headings={headings}


### PR DESCRIPTION
Closes #723 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Fix to #723: Custom scrollbars are not displayed on Firefox (see screenshot).

OS: Windows.

---

## Screenshots

Problem:

![t3_bug](https://user-images.githubusercontent.com/69996340/201532436-3b975dec-5240-4e47-9d29-ee3ddc0d0826.png)

Update:

![resolved](https://user-images.githubusercontent.com/69996340/201535079-7477f700-049e-4729-85fd-d17b9c037c84.png)

💯
