### PR TITLE
docs(tRPC): Switch to new `setData` signature

### DIFF
--- a/www/src/pages/en/usage/trpc.md
+++ b/www/src/pages/en/usage/trpc.md
@@ -258,10 +258,13 @@ const MyComponent = () => {
     async onMutate(newPost) {
       // Cancel outgoing fetches (so they don't overwrite our optimistic update)
       await utils.post.list.cancel();
+
       // Get the data from the queryCache
       const prevData = utils.post.list.getData();
+
       // Optimistically update the data with our new post
-      utils.post.list.setData([...prevData, newPost ]);
+      utils.post.list.setData(undefined, old => [...old, newPost ]);
+
       // Return the previous data so we can revert if something goes wrong
       return { prevData };
     },

--- a/www/src/pages/en/usage/trpc.md
+++ b/www/src/pages/en/usage/trpc.md
@@ -270,7 +270,7 @@ const MyComponent = () => {
     },
     onError(err, newPost, ctx) {
       // If the mutation fails, use the context-value from onMutate
-      utils.post.list.setData(ctx.prevData);
+      utils.post.list.setData(undefined, ctx.prevData);
     }
     onSettled() {
       // Sync with server once mutation has settled

--- a/www/src/pages/en/usage/trpc.md
+++ b/www/src/pages/en/usage/trpc.md
@@ -263,7 +263,7 @@ const MyComponent = () => {
       const prevData = utils.post.list.getData();
 
       // Optimistically update the data with our new post
-      utils.post.list.setData(undefined, old => [...old, newPost ]);
+      utils.post.list.setData(undefined, (old) => [...old, newPost]);
 
       // Return the previous data so we can revert if something goes wrong
       return { prevData };


### PR DESCRIPTION



## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

The signature for `setData` has changed. This commit will do two things:
- Provide `undefined` for the input argument (mandatory).
- Use the updater function (`old => [...old, newPost ]`) instead of the `prevData` directly. This makes it also align with the React Query docs:
  
  ![image](https://user-images.githubusercontent.com/29319414/201920826-fe72121e-3fbe-4cd0-9e3c-b63a3b56f8b8.png)


