### PR TITLE
fix: layout shift on docs

### DIFF
--- a/www/src/components/navigation/themeToggleButton.astro
+++ b/www/src/components/navigation/themeToggleButton.astro
@@ -1,5 +1,5 @@
 <div
-  class="flex bg-t3-purple-200/50 hover:bg-t3-purple-200/75 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:hover:border-t3-purple-200/50 duration-300 p-2 w-fit mx-auto rounded-lg gap-3"
+  class="flex bg-t3-purple-200/50 hover:bg-t3-purple-200/75 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:hover:border-t3-purple-200/50 p-2 w-fit mx-auto rounded-lg gap-3"
 >
   <label class="cursor-pointer text-t3-purple-500 dark:text-slate-50">
     <!-- Sun -->

--- a/www/src/layouts/docs.astro
+++ b/www/src/layouts/docs.astro
@@ -65,9 +65,7 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
     </script>
   </head>
 
-  <body
-    class="bg-default min-h-screen flex flex-col items-center transition-all duration-300"
-  >
+  <body class="bg-default min-h-screen flex flex-col items-center">
     <JumpToContent />
     <div
       class="bg-default sticky top-0 w-full max-h-full z-40 transition-colors duration-300"

--- a/www/src/layouts/docs.astro
+++ b/www/src/layouts/docs.astro
@@ -89,7 +89,9 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
     </script>
   </head>
 
-  <body class="bg-default min-h-screen flex flex-col items-center">
+  <body
+    class="bg-default min-h-screen flex flex-col items-center transition-colors duration-300"
+  >
     <JumpToContent />
     <div
       class="bg-default sticky top-0 w-full max-h-full z-40 transition-colors duration-300"


### PR DESCRIPTION
Closes #738

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog
Prevent applying of global transitions
Remove transition duration for Theme Toggle

---

## Screenshots
Before:
https://user-images.githubusercontent.com/3381481/202189087-f8749ba9-b495-475d-a5aa-45a96d76ad31.mp4

After:
https://user-images.githubusercontent.com/3381481/202189122-f3705922-c9f7-4067-bef2-c20e48eb18b1.mp4


## Comments
I could only replicate the issue seen on the [Docs](https://beta.create.t3.gg/en/introduction) when running `pnpm build` and `pnpm preview` from `/www`
For reasons beyond my small brain, I could not replicate with `pnpm build:www` running from root.


💯