### PR TITLE
feat: open links to external sites in new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,8 @@
     "prettier": "^2.7.1",
     "turbo": "^1.5.5",
     "typescript": "^4.8.4"
+  },
+  "devDependencies": {
+    "rehype-external-links": "^2.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ importers:
       eslint-plugin-react-hooks: ^4.6.0
       eslint-plugin-unicorn: 44.0.0
       prettier: ^2.7.1
+      rehype-external-links: ^2.0.1
       turbo: ^1.5.5
       typescript: ^4.8.4
     dependencies:
@@ -37,6 +38,8 @@ importers:
       prettier: 2.7.1
       turbo: 1.5.5
       typescript: 4.8.4
+    devDependencies:
+      rehype-external-links: 2.0.1
 
   cli:
     specifiers:
@@ -3827,6 +3830,11 @@ packages:
       has: 1.0.3
       side-channel: 1.0.4
 
+  /is-absolute-url/4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /is-alphabetical/2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
     dev: true
@@ -5537,6 +5545,17 @@ packages:
     dependencies:
       rc: 1.2.8
     dev: false
+
+  /rehype-external-links/2.0.1:
+    resolution: {integrity: sha512-u2dNypma+ps12SJWlS23zvbqwNx0Hl24t0YHXSM/6FCZj/pqWETCO3WyyrvALv4JYvRtuPjhiv2Lpen15ESqbA==}
+    dependencies:
+      '@types/hast': 2.3.4
+      extend: 3.0.2
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.1
+      unified: 10.1.2
+      unist-util-visit: 4.1.1
+    dev: true
 
   /rehype-parse/8.0.4:
     resolution: {integrity: sha512-MJJKONunHjoTh4kc3dsM1v3C9kGrrxvA3U8PxZlP2SjH8RNUSrb+lF7Y0KVaUDnGH2QZ5vAn7ulkiajM9ifuqg==}

--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import tailwind from "@astrojs/tailwind";
 import image from "@astrojs/image";
-
+import rehypeExternalLinks from "rehype-external-links";
 import remarkCodeTitles from "remark-code-titles";
 
 /**
@@ -12,6 +12,15 @@ export default defineConfig({
   site: `https://beta.create.t3.gg`,
   markdown: {
     remarkPlugins: [remarkCodeTitles],
+    rehypePlugins: [
+      [
+        rehypeExternalLinks,
+        {
+          target: "_blank",
+          rel: ["noreferrer noopener"],
+        },
+      ],
+    ],
     shikiConfig: {
       theme: "rose-pine",
       wrap: true,


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

added a rehype plugin to open external links in new tab.
