### PR TITLE
docs: add "why not `/app`?" FAQ

### DIFF
--- a/www/src/pages/en/faq.md
+++ b/www/src/pages/en/faq.md
@@ -50,3 +50,7 @@ We try to emphasize that these files are javascript for a reason, by explicitly 
 We have decided against including i18n by default in `create-t3-app` because it's a very opinionated topic and there are many ways to implement it.
 
 However, if you struggle to implement it and want to see a reference project, we have a [reference repo](https://github.com/juliusmarminge/t3-i18n) that shows how you can add i18n to a T3 App using [next-i18next](https://github.com/i18next/next-i18next).
+
+## Why are we using `/pages` and not `/app` from Next.js 13?
+
+As per [T3-Axiom #2](/en/introduction#bleed-responsibly), we love bleeding edge stuff but value stability, especialy in parts as crucial as the router. While `/app` is a glimpse into the future, it's not ready for production; The API is in beta and expected to have breaking changes. For a list of supported, planned, and worked on features in the `/app` dir, visit the [beta Next.js docs](https://beta.nextjs.org/docs/app-directory-roadmap#supported-and-planned-features).

--- a/www/src/pages/en/faq.md
+++ b/www/src/pages/en/faq.md
@@ -53,6 +53,6 @@ However, if you struggle to implement it and want to see a reference project, we
 
 ## Why are we using `/pages` and not `/app` from Next.js 13?
 
-As per [T3-Axiom #2](/en/introduction#bleed-responsibly), we love bleeding edge stuff but value stability, especialy in parts as crucial as the router. While `/app` is a glimpse into the future, it's not ready for production; The API is in beta and expected to have breaking changes.
+As per [T3-Axiom #2](/en/introduction#bleed-responsibly), we love bleeding edge stuff but value stability, especialy in parts as crucial as the router. While `/app` is [a glimpse into the future](https://youtu.be/rnsC-12PVlM?t=818), it's not ready for production; The API is in beta and expected to have breaking changes.
 
 For a list of supported, planned, and worked on features in the `/app` dir, visit the [beta Next.js docs](https://beta.nextjs.org/docs/app-directory-roadmap#supported-and-planned-features).

--- a/www/src/pages/en/faq.md
+++ b/www/src/pages/en/faq.md
@@ -53,4 +53,6 @@ However, if you struggle to implement it and want to see a reference project, we
 
 ## Why are we using `/pages` and not `/app` from Next.js 13?
 
-As per [T3-Axiom #2](/en/introduction#bleed-responsibly), we love bleeding edge stuff but value stability, especialy in parts as crucial as the router. While `/app` is a glimpse into the future, it's not ready for production; The API is in beta and expected to have breaking changes. For a list of supported, planned, and worked on features in the `/app` dir, visit the [beta Next.js docs](https://beta.nextjs.org/docs/app-directory-roadmap#supported-and-planned-features).
+As per [T3-Axiom #2](/en/introduction#bleed-responsibly), we love bleeding edge stuff but value stability, especialy in parts as crucial as the router. While `/app` is a glimpse into the future, it's not ready for production; The API is in beta and expected to have breaking changes.
+
+For a list of supported, planned, and worked on features in the `/app` dir, visit the [beta Next.js docs](https://beta.nextjs.org/docs/app-directory-roadmap#supported-and-planned-features).

--- a/www/src/pages/en/faq.md
+++ b/www/src/pages/en/faq.md
@@ -53,6 +53,6 @@ However, if you struggle to implement it and want to see a reference project, we
 
 ## Why are we using `/pages` and not `/app` from Next.js 13?
 
-As per [T3-Axiom #2](/en/introduction#bleed-responsibly), we love bleeding edge stuff but value stability, especialy in parts as crucial as the router. While `/app` is [a glimpse into the future](https://youtu.be/rnsC-12PVlM?t=818), it's not ready for production; The API is in beta and expected to have breaking changes.
+As per [T3-Axiom #2](/en/introduction#bleed-responsibly), we love bleeding edge stuff but value stability, your entire router is hard to port, [not a great place to bleed](https://youtu.be/mnwUbtieOuI?t=1662). While `/app` is [a glimpse into the future](https://youtu.be/rnsC-12PVlM?t=818), it's not ready for production; The API is in beta and expected to have breaking changes.
 
 For a list of supported, planned, and worked on features in the `/app` dir, visit the [beta Next.js docs](https://beta.nextjs.org/docs/app-directory-roadmap#supported-and-planned-features).


### PR DESCRIPTION
## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

Added an FAQ item responding to the common question of "Why aren't you using the `/app` folder from Next.js 13??".

---

## Screenshots

![image](https://user-images.githubusercontent.com/37847523/202330020-73b2d40b-1fed-4d7e-be2f-3acbbf789d6c.png)


💯
