### PR TITLE
fix: tweet slider pausing permanently on hover

### DIFF
--- a/www/src/components/landingPage/tweets/tweetSlider.astro
+++ b/www/src/components/landingPage/tweets/tweetSlider.astro
@@ -62,6 +62,7 @@ const { tweets } = Astro.props as Props;
       autoplay({
         delay: 3000,
         stopOnMouseEnter: true,
+        stopOnInteraction: false,
       }),
     ],
   );


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Fixed issue with tweet slider pausing permanently after hover

---

💯
