### PR TITLE
docs: made themeToggleButton a toggle button

### DIFF
--- a/www/src/components/navigation/themeToggleButton.astro
+++ b/www/src/components/navigation/themeToggleButton.astro
@@ -35,13 +35,13 @@
 
   const themeToggle = document.querySelector('[name="theme-toggle"]');
 
-  const message = () => {
+  const getMessage = () => {
     const theme = html.classList.contains("dark") ? "light" : "dark";
     return `Use ${theme}-mode`;
   };
 
-  themeToggle!.setAttribute("title", message());
-  themeToggle!.setAttribute("aria-label", message());
+  themeToggle!.setAttribute("title", getMessage());
+  themeToggle!.setAttribute("aria-label", getMessage());
   themeToggle!.setAttribute(
     "value",
     html.classList.contains("dark") ? "dark" : "light",
@@ -51,8 +51,8 @@
     localStorage.setItem("theme", t);
     html.classList.add(t === "dark" ? "dark" : "light");
     html.classList.remove(t === "dark" ? "light" : "dark");
-    themeToggle!.setAttribute("title", message());
-    themeToggle!.setAttribute("aria-label", message());
+    themeToggle!.setAttribute("title", getMessage());
+    themeToggle!.setAttribute("aria-label", getMessage());
     themeToggle!.setAttribute("value", t);
   };
 

--- a/www/src/components/navigation/themeToggleButton.astro
+++ b/www/src/components/navigation/themeToggleButton.astro
@@ -1,5 +1,6 @@
-<div
+<button
   class="flex bg-t3-purple-200/50 hover:bg-t3-purple-200/75 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:hover:border-t3-purple-200/50 p-2 w-fit mx-auto rounded-lg gap-3"
+  name="theme-toggle"
 >
   <label class="cursor-pointer text-t3-purple-500 dark:text-slate-50">
     <!-- Sun -->
@@ -14,15 +15,6 @@
         d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
       ></path>
     </svg>
-
-    <input
-      class="absolute invisible"
-      type="radio"
-      name="theme-toggle"
-      value="light"
-      title="use light-mode"
-      aria-label="use light-mode"
-    />
   </label>
   <label class="cursor-pointer dark:text-t3-purple-500 text-slate-900">
     <!-- Moon -->
@@ -35,33 +27,36 @@
         d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"
       ></path>
     </svg>
-    <input
-      class="absolute invisible"
-      type="radio"
-      name="theme-toggle"
-      value="dark"
-      title="use dark-mode"
-      aria-label="use dark-mode"
-    />
   </label>
-</div>
+</button>
 
 <script>
   const html = document.documentElement;
 
-  const lightToggle = document.querySelector(
-    'input[name="theme-toggle"][value="light"]',
-  );
-  const darkToggle = document.querySelector(
-    'input[name="theme-toggle"][value="dark"]',
+  const themeToggle = document.querySelector('[name="theme-toggle"]');
+
+  const message = () => {
+    const theme = html.classList.contains("dark") ? "light" : "dark";
+    return `Use ${theme}-mode`;
+  };
+
+  themeToggle!.setAttribute("title", message());
+  themeToggle!.setAttribute("aria-label", message());
+  themeToggle!.setAttribute(
+    "value",
+    html.classList.contains("dark") ? "dark" : "light",
   );
 
   const toggleTheme = (t: "light" | "dark") => {
     localStorage.setItem("theme", t);
     html.classList.add(t === "dark" ? "dark" : "light");
     html.classList.remove(t === "dark" ? "light" : "dark");
+    themeToggle!.setAttribute("title", message());
+    themeToggle!.setAttribute("aria-label", message());
+    themeToggle!.setAttribute("value", t);
   };
 
-  lightToggle!.addEventListener("change", () => toggleTheme("light"));
-  darkToggle!.addEventListener("change", () => toggleTheme("dark"));
+  themeToggle!.addEventListener("click", () => {
+    toggleTheme(html.classList.contains("dark") ? "light" : "dark");
+  });
 </script>


### PR DESCRIPTION
Closes #781 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Refactored themeToggleButton to use a `<button>` root element instead of 2 radio buttons so that the light/dark theme gets toggled regardless of where the user presses within the component.

The component's `title`, `value` and `aria-label` attributes gets set on page-load using the appropriate dark/light state.

---

## Screenshots

![theme toggle 3](https://user-images.githubusercontent.com/10285764/202717747-6ad1443b-162c-4f08-a8aa-a9b41b9f0d9c.gif)

💯
