### PR TITLE
fix: removing redundant optional chaining in templates

### DIFF
--- a/.changeset/thick-yaks-exist.md
+++ b/.changeset/thick-yaks-exist.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: removing redundant optional chaining in templates

--- a/cli/template/page-studs/index/with-auth-trpc-tw.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc-tw.tsx
@@ -67,7 +67,7 @@ const AuthShowcase: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center gap-4">
       <p className="text-center text-2xl text-white">
-        {sessionData && <span>Logged in as {sessionData?.user?.name}</span>}
+        {sessionData && <span>Logged in as {sessionData.user?.name}</span>}
         {secretMessage && <span> - {secretMessage}</span>}
       </p>
       <button

--- a/cli/template/page-studs/index/with-auth-trpc.tsx
+++ b/cli/template/page-studs/index/with-auth-trpc.tsx
@@ -62,7 +62,7 @@ const AuthShowcase: React.FC = () => {
   return (
     <div className={styles.authContainer}>
       <p className={styles.showcaseText}>
-        {sessionData && <span>Logged in as {sessionData?.user?.name}</span>}
+        {sessionData && <span>Logged in as {sessionData.user?.name}</span>}
         {secretMessage && <span> - {secretMessage}</span>}
       </p>
       <button


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

Removed the optional chaining on `sessionData`. It is already verified at the start of the line.

---

💯
