### PR TITLE
fix: overlapping scrollbars in docs

### DIFF
--- a/www/src/layouts/docs.astro
+++ b/www/src/layouts/docs.astro
@@ -93,17 +93,19 @@ const githubEditUrl = `${CONFIG.GITHUB_EDIT_URL}/${currentFile}`;
         </nav>
         <Footer path={currentFile} isBlog={true} />
       </div>
-      <aside
-        id="grid-right"
-        title="Table of Contents"
-        class="t3-scrollbar hidden lg:mb-12 lg:flex lg:flex-col lg:justify-start sticky col-span-1 w-full h-auto max-h-[calc(100vh-100px)] pr-4 top-[100px]"
-      >
-        <RightSidebar
-          headings={headings}
-          githubEditUrl={githubEditUrl}
-          title={frontmatter.title}
-        />
-      </aside>
+      <div class="md:mr-4">
+        <aside
+          id="grid-right"
+          title="Table of Contents"
+          class="t3-scrollbar hidden lg:mb-12 lg:flex lg:flex-col lg:justify-start sticky col-span-1 w-full h-auto max-h-[calc(100vh-100px)] pr-4 top-[100px]"
+        >
+          <RightSidebar
+            headings={headings}
+            githubEditUrl={githubEditUrl}
+            title={frontmatter.title}
+          />
+        </aside>
+      </div>
     </main>
     <script defer>
       const matches = document.querySelectorAll("[data-heading-link]");


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The scrollbars of the right nav and the body were overlapping on some screen sizes. Fixed this by adding a spacer that shifts the right nav when necessary. The scrollbar now lines up with the end of the search box above it at all screen sizes.

---

## Screenshots

Before:
<img width="1388" alt="Screenshot 2022-11-19 at 09 56 49" src="https://user-images.githubusercontent.com/8353666/202845326-b749a2b1-da98-45b8-a611-272d1c245f00.png">

After:
<img width="1319" alt="Screenshot 2022-11-19 at 09 52 08" src="https://user-images.githubusercontent.com/8353666/202845297-e77c75f6-6d72-4ada-8c72-bdf5a2ce5647.png">

<img width="1552" alt="Screenshot 2022-11-19 at 09 52 16" src="https://user-images.githubusercontent.com/8353666/202845304-25f6fe30-b282-45cb-9590-933763ab8f13.png">

💯
