### PR TITLE
fix(docs): Fixed wrong alt attribute

### DIFF
--- a/www/src/pages/en/usage/typescript.md
+++ b/www/src/pages/en/usage/typescript.md
@@ -12,7 +12,7 @@ layout: ../../../layouts/docs.astro
   </div>
   <cite className="flex items-center justify-end pr-4 pb-2">
     <img
-      alt="Avatar of @alexdotjs"
+      alt="Avatar of @t3dotgg"
       className="w-12 mr-4 rounded-full bg-neutral-500"
       src="/images/theo_300x300.webp"
     />


### PR DESCRIPTION

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Changed "Avatar of @alexdotjs" to "Avatar of @t3dotgg" in the "alt" attribute for Theo's profile picture on TypeScript page.

---

## Screenshots

![image](https://user-images.githubusercontent.com/35634442/203015267-bd45f1f5-f666-49b1-a820-aa0634523e30.png)


💯
