### PR TITLE
fix: enable NEXTAUTH_SECRET by default

### DIFF
--- a/cli/src/installers/envVars.ts
+++ b/cli/src/installers/envVars.ts
@@ -38,7 +38,7 @@ DATABASE_URL=file:./db.sqlite
 # Next Auth
 # You can generate the secret via 'openssl rand -base64 32' on Linux
 # More info: https://next-auth.js.org/configuration/options#secret
-# NEXTAUTH_SECRET=
+NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3000
 
 # Next Auth Discord Provider


### PR DESCRIPTION
NEXTAUTH_SECRET is not enabled by default but Discord provider keys are. Next-auth needs to have NEXTAUTH_SECRET and its also checked on schema.

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯
