### PR TITLE
feat(readme): URL swap to new docs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  Get started with the <a rel="noopener noreferrer" target="_blank" href="https://init.tips">T3 Stack</a> by running <code>npm create t3-app@latest</code>
+  Get started with the <a rel="noopener noreferrer" target="_blank" href="https://create.t3.gg/en/installation">T3 Stack</a> by running <code>npm create t3-app@latest</code>
 </p>
 
 <div align="center">


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Nothing special, Replaced the current init URL in the README with the new Docs URL.

---

## Screenshots

![Screenshot 2022-11-22 162553](https://user-images.githubusercontent.com/60965908/203353466-a560336b-8736-4d7a-a7a1-9e1b179cf0bc.png)
screenshot of running dev env just in case (didn't change anything but well, why not)

💯
