### PR TITLE
docs(RFC): external link glyph

### DIFF
--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -18,6 +18,10 @@ export default defineConfig({
         {
           target: "_blank",
           rel: ["noreferrer noopener"],
+          content: {
+            type: "text",
+            value: "↗",
+          },
         },
       ],
       "rehype-slug",

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -162,10 +162,6 @@
           dark:decoration-t3-purple-200 dark:hover:text-t3-purple-300;
   }
 
-  .markdown a[rel~="noreferrer"] > span {
-    @apply pl-1;
-  }
-
   .markdown code {
     @apply break-words lg:break-normal;
   }

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -154,6 +154,10 @@
           dark:decoration-t3-purple-200 dark:hover:text-t3-purple-300;
   }
 
+  .markdown a[rel~="noreferrer"] > span {
+    @apply pl-1;
+  }
+
   .markdown code {
     @apply break-words lg:break-normal;
   }


### PR DESCRIPTION
was brought up in another pr that we should mark external links.

not sure if I like it or not myself

<img width="761" alt="CleanShot 2022-11-25 at 09 17 37@2x" src="https://user-images.githubusercontent.com/51714798/203934438-8197c6a1-6f2f-4fd7-800b-aec947ae266c.png">
