### PR TITLE
docs: Fix spelling of Tailwind in folder-structure.md

### DIFF
--- a/www/src/pages/en/folder-structure.md
+++ b/www/src/pages/en/folder-structure.md
@@ -213,7 +213,7 @@ The `next.config.mjs` file is used to configure Next.js. See [Next.js Docs](http
 
 ### `postcss.config.cjs`
 
-The `postcss.config.cjs` file is used for Tailwind PostCSS usage. See [Taiwind PostCSS Docs](https://tailwindcss.com/docs/installation/using-postcss) for more information.
+The `postcss.config.cjs` file is used for Tailwind PostCSS usage. See [Tailwind PostCSS Docs](https://tailwindcss.com/docs/installation/using-postcss) for more information.
 
 <sub>(with Tailwind CSS)</sub>
 


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Updated the spelling of tailwind in the folder structure docs.

---

💯
