### PR TITLE
docs: improve language select styling

### DIFF
--- a/www/src/components/navigation/LanguageSelect.tsx
+++ b/www/src/components/navigation/LanguageSelect.tsx
@@ -16,7 +16,7 @@ export default function LanguageSelect({ language }: LanguageSelectProps) {
   return (
     <div className="flex items-center gap-2">
       <Listbox value={language} onChange={handleSelect}>
-        <div className="relative mt-1">
+        <div className="relative">
           <Listbox.Button className="relative flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border bg-t3-purple-200/50 text-left focus:outline-none hover:bg-t3-purple-200/75 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50 sm:text-sm">
             <svg
               viewBox="0 0 88.6 77.3"
@@ -35,16 +35,16 @@ export default function LanguageSelect({ language }: LanguageSelectProps) {
           </Listbox.Button>
           <Transition
             as={Fragment}
-            leave="transition ease-in duration-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
+            enter={"transition ease-out duration-100"}
+            enterFrom={"transform opacity-0 -translate-y-1"}
+            enterTo={"transform opacity-100 -translate-y-0"}
           >
-            <Listbox.Options className="dark:border-t3-purple-200/50py-1 shadow-l absolute right-0 mt-1 max-h-60 w-fit overflow-auto rounded-lg bg-default text-base focus:outline-none focus-visible:outline-none dark:border-t3-purple-200/50 sm:text-sm">
+            <Listbox.Options className="shadow-l absolute right-0 mt-1 max-h-60 w-fit overflow-auto rounded-lg border bg-default text-base focus:outline-none focus-visible:outline-none dark:border-t3-purple-200/20 sm:text-sm">
               {Object.entries(KNOWN_LANGUAGES).map(([code, name]) => (
                 <Listbox.Option
                   key={code}
                   className={({ selected, active }) =>
-                    `relative cursor-pointer bg-t3-purple-200/50 py-1 px-3 text-slate-900 outline-none hover:bg-t3-purple-200/75 dark:bg-t3-purple-200/10 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/20 ${
+                    `relative cursor-pointer bg-t3-purple-200/50 py-2 px-4 text-slate-900 outline-none hover:bg-t3-purple-200/75 dark:bg-t3-purple-200/10 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/20 ${
                       (selected || active) &&
                       "bg-t3-purple-200/75 dark:bg-t3-purple-200/20"
                     }`

--- a/www/src/components/navigation/LanguageSelect.tsx
+++ b/www/src/components/navigation/LanguageSelect.tsx
@@ -17,7 +17,7 @@ export default function LanguageSelect({ language }: LanguageSelectProps) {
     <div className="flex items-center gap-2">
       <Listbox value={language} onChange={handleSelect}>
         <div className="relative">
-          <Listbox.Button className="relative flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border bg-t3-purple-200/50 text-left focus:outline-none hover:bg-t3-purple-200/75 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50 sm:text-sm">
+          <Listbox.Button className="relative flex cursor-pointer items-center justify-center rounded-lg border bg-t3-purple-200/50 p-2 text-left focus:outline-none hover:bg-t3-purple-200/75 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50 sm:text-sm">
             <svg
               viewBox="0 0 88.6 77.3"
               className="h-6 w-6 text-slate-900 dark:text-t3-purple-100"


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Improved the language select dropdown animation
- Removed margin top from language select button that made it look asymmetrical
- Added a border to the language select dropdown in dark mode
- Increased padding of the language select dropdown to make it look less narrow (I'm not sure if this looks good or not, tell me if it doesn't and I'll remove it 👍)

From (Notice how the language select button is not properly aligned with the rest of the buttons in the header. It has a slight margin top)
![Bildschirmfoto 2022-11-26 um 20 05 28](https://user-images.githubusercontent.com/61044138/204105128-0b99d674-473e-496a-aaed-8be141cdac93.png)

To
![Bildschirmfoto 2022-11-26 um 20 05 53](https://user-images.githubusercontent.com/61044138/204105134-ff65bda6-341c-4f86-b4f4-16f62d5b0be3.png)
