### PR TITLE
fix(docs): added scroll-margin to headings

### DIFF
--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -106,6 +106,15 @@
     @apply scrollbar-thin scrollbar-track-slate-300 scrollbar-thumb-t3-purple-300 dark:scrollbar-track-t3-purple-200/10 dark:scrollbar-thumb-t3-purple-300;
   }
 
+  h1[id],
+  h2[id],
+  h3[id],
+  h4[id],
+  h5[id],
+  #content {
+    @apply scroll-mt-24;
+  }
+
   /* only at less than md */
   @media (max-width: 767.5px) {
     .mobile-sidebar-toggle {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

#867 removed scroll padding from the page, now when you open a link with a hash to a specific section of the page (for example https://create.t3.gg/en/introduction#the-t3-stack) the heading of the section is hidden behind the header. This PR fixes that without breaking the language selector.

---

## Screenshots

![2022-11-26 23-01-31](https://user-images.githubusercontent.com/35634442/204110497-aed58acd-1aa6-464c-9e90-249f54f6cc0d.gif)


💯
