### PR TITLE
docs: accessibility improvements

### DIFF
--- a/www/src/components/landingPage/stack/stack.astro
+++ b/www/src/components/landingPage/stack/stack.astro
@@ -24,7 +24,11 @@ import Feature from "./card.astro";
       <div
         class="space-y-10 sm:grid sm:grid-flow-col sm:grid-cols-2 sm:grid-rows-3 sm:gap-x-6 sm:gap-y-14 sm:space-y-0 md:grid-cols-3 md:grid-rows-2 lg:gap-x-8"
       >
-        <Feature title="Next.js" href="https://nextjs.org/" aria-hidden={true}>
+        <Feature
+           title="Next.js"
+           href="https://nextjs.org/"
+           aria-hidden={true}
+         >
           <svg
             slot="icon"
             role="img"

--- a/www/src/components/landingPage/stack/stack.astro
+++ b/www/src/components/landingPage/stack/stack.astro
@@ -24,7 +24,7 @@ import Feature from "./card.astro";
       <div
         class="space-y-10 sm:grid sm:grid-flow-col sm:grid-cols-2 sm:grid-rows-3 sm:gap-x-6 sm:gap-y-14 sm:space-y-0 md:grid-cols-3 md:grid-rows-2 lg:gap-x-8"
       >
-        <Feature title="Next.js" href="https://nextjs.org/">
+        <Feature title="Next.js" href="https://nextjs.org/" aria-hidden={true}>
           <svg
             slot="icon"
             role="img"
@@ -45,7 +45,11 @@ import Feature from "./card.astro";
             we're proud to build on top of it :)
           </Fragment>
         </Feature>
-        <Feature title="Prisma" href="https://www.prisma.io/">
+        <Feature
+          title="Prisma"
+          href="https://www.prisma.io/"
+          aria-hidden={true}
+        >
           <svg
             slot="icon"
             role="img"
@@ -65,7 +69,11 @@ import Feature from "./card.astro";
           </Fragment>
         </Feature>
 
-        <Feature title="TypeScript" href="https://www.typescriptlang.org/">
+        <Feature
+          title="TypeScript"
+          href="https://www.typescriptlang.org/"
+          aria-hidden={true}
+        >
           <svg
             slot="icon"
             version="1.1"
@@ -89,7 +97,11 @@ import Feature from "./card.astro";
           </Fragment>
         </Feature>
 
-        <Feature title="Tailwind CSS" href="https://tailwindcss.com/">
+        <Feature
+          title="Tailwind CSS"
+          href="https://tailwindcss.com/"
+          aria-hidden={true}
+        >
           <svg
             slot="icon"
             role="img"
@@ -110,7 +122,7 @@ import Feature from "./card.astro";
           </Fragment>
         </Feature>
 
-        <Feature title="tRPC" href="https://trpc.io/">
+        <Feature title="tRPC" href="https://trpc.io/" aria-hidden={true}>
           <svg
             slot="icon"
             viewBox="0 0 512 512"
@@ -131,7 +143,11 @@ import Feature from "./card.astro";
           </Fragment>
         </Feature>
 
-        <Feature title="NextAuth.js" href="https://next-auth.js.org/">
+        <Feature
+          title="NextAuth.js"
+          href="https://next-auth.js.org/"
+          aria-hidden={true}
+        >
           <img
             src="/images/nextauth.webp"
             slot="icon"

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -63,6 +63,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
                 },
               )}
               href={navbarLink.href}
+              aria-current={navbarLink.href === currentPage}
             >
               {navbarLink.label}
             </a>

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -36,7 +36,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
 >
   <div class="flex w-full max-w-7xl items-center justify-between px-4">
     <div class="flex w-full items-center justify-between md:w-auto">
-      <div>
+      <div class="focus-within:ring-2 focus-within:ring-t3-purple-800">
         <a href="/">
           <img
             src="/favicon.svg"
@@ -56,9 +56,9 @@ const navbarLinks: Array<{ href: string; label: string }> = [
                 {
                   "bg-t3-purple-200/50 text-t3-purple-800 dark:bg-t3-purple-200/10":
                     navbarLink.href === currentPage,
-                  "rounded-lg text-t3-purple-100 hover:bg-t3-purple-200/10 hover:text-t3-purple-300":
+                  "text-t3-purple-100 hover:bg-t3-purple-200/10 hover:text-t3-purple-300 rounded-lg":
                     isLanding,
-                  "rounded-lg text-t3-purple-800 hover:bg-t3-purple-200/50 hover:text-t3-purple-800 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
+                  "text-t3-purple-800 hover:bg-t3-purple-200/50 hover:text-t3-purple-800 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300 rounded-lg":
                     !isLanding,
                 },
               )}

--- a/www/src/components/navigation/themeToggleButton.astro
+++ b/www/src/components/navigation/themeToggleButton.astro
@@ -8,7 +8,7 @@
       xmlns="http://www.w3.org/2000/svg"
       class="h-6 w-6 fill-current stroke-current stroke-2 transition-colors duration-300"
       viewBox="0 0 24 24"
-      aria-label="light mode"
+      aria-label="use light-mode"
     >
       <path
         stroke-linecap="round"
@@ -23,7 +23,7 @@
       xmlns="http://www.w3.org/2000/svg"
       class="h-6 w-6 fill-current stroke-current transition-colors duration-300"
       viewBox="0 0 20 20"
-      aria-label="dark mode"
+      aria-label="use dark-mode"
     >
       <path
         d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"

--- a/www/src/components/navigation/themeToggleButton.astro
+++ b/www/src/components/navigation/themeToggleButton.astro
@@ -8,6 +8,7 @@
       xmlns="http://www.w3.org/2000/svg"
       class="h-6 w-6 fill-current stroke-current stroke-2 transition-colors duration-300"
       viewBox="0 0 24 24"
+      aria-label="light mode"
     >
       <path
         stroke-linecap="round"
@@ -22,6 +23,7 @@
       xmlns="http://www.w3.org/2000/svg"
       class="h-6 w-6 fill-current stroke-current transition-colors duration-300"
       viewBox="0 0 20 20"
+      aria-label="dark mode"
     >
       <path
         d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"

--- a/www/src/pages/en/usage/trpc.md
+++ b/www/src/pages/en/usage/trpc.md
@@ -114,7 +114,7 @@ import { useRouter } from "next/router";
 
 const UserPage = () => {
   const { query } = useRouter();
-  const userQuery = trpc.user.getById.useQuery(query.id);
+  const userQuery = trpc.users.getById.useQuery(query.id);
 
   return (
     <div>


### PR DESCRIPTION
Partially closes #881

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Addressed some points listed in #881 
- aria-current for docs navbar
- aria-labels on theme toggle images
- aria-hidden on library card logos as the names are right next to them, prevents double name reading on SR
- Focus outline styling needed on T3 logo in navbar
---

💯
