### PR TITLE
feat: using 'init.defaultBranch' when initializing git repo

### DIFF
--- a/.changeset/late-beds-jump.md
+++ b/.changeset/late-beds-jump.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+When initializing a new git repo the git config value 'init.defaultBranch' will be used as the branch name

--- a/cli/src/helpers/git.ts
+++ b/cli/src/helpers/git.ts
@@ -44,6 +44,13 @@ const getGitVersion = () => {
   return { major: Number(major), minor: Number(minor) };
 };
 
+const getDefaultBranch = () => {
+  const stdout = execSync("git config --global init.defaultBranch")
+    .toString()
+    .trim();
+  return stdout || "main";
+};
+
 // This initializes the Git-repository for the project
 export const initializeGit = async (projectDir: string) => {
   logger.info("Initializing Git...");
@@ -99,13 +106,15 @@ export const initializeGit = async (projectDir: string) => {
 
   // We're good to go, initializing the git repo
   try {
+    const branchName = getDefaultBranch();
+
     // --initial-branch flag was added in git v2.28.0
     const { major, minor } = getGitVersion();
     if (major < 2 || minor < 28) {
       await execa("git", ["init"], { cwd: projectDir });
-      await execa("git", ["branch", "-m", "main"], { cwd: projectDir });
+      await execa("git", ["branch", "-m", branchName], { cwd: projectDir });
     } else {
-      await execa("git", ["init", "--initial-branch=main"], {
+      await execa("git", ["init", `--initial-branch=${branchName}`], {
         cwd: projectDir,
       });
     }

--- a/cli/src/helpers/git.ts
+++ b/cli/src/helpers/git.ts
@@ -44,11 +44,13 @@ const getGitVersion = () => {
   return { major: Number(major), minor: Number(minor) };
 };
 
+/** If git config value 'init.defaultBranch' is set return value else 'main' */
 const getDefaultBranch = () => {
-  const stdout = execSync("git config --global init.defaultBranch")
+  const stdout = execSync("git config --global init.defaultBranch || echo main")
     .toString()
     .trim();
-  return stdout || "main";
+
+  return stdout;
 };
 
 // This initializes the Git-repository for the project


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog
Introduced new function `getDefaultBranch()` in `./cli/src/helpers/git.ts`, which either returns the default branch name configured on the users computer or `main`.
Said function is called everytime the user decides to automatically initialize a git repository to set the default branch

---

## Screenshots

_[Screenshots]_

💯
