### PR TITLE
docs: fix the engHref at outdated bunner

### DIFF
--- a/www/src/components/docs/outdatedDocsBanner.astro
+++ b/www/src/components/docs/outdatedDocsBanner.astro
@@ -54,27 +54,30 @@ Astro.response.headers.set("Cache-Control", `s-max-age=${ONE_WEEK}`);
 ---
 
 {
-  diffInDays > 0 && (
-    <div
-      dir="ltr"
-      class="mx-2 mb-8 w-full rounded-lg bg-t3-purple-200/50 p-4 font-medium dark:bg-t3-purple-200/10"
-    >
-      <p>
-        Attention: This page is{" "}
-        <span class="font-extrabold">
-          {diffInDays} {diffInDays === 1 ? "day" : "days"}
-        </span>
-        older than the English version and might be outdated. If you're a native
-        speaker of this language and would like to contribute to the project,
-        please consider updating this page to match the latest English version.
-      </p>
-      <p class="mt-3">
-        You can also{" "}
-        <a class="text-t3-purple-400" href={engHref}>
-          view the English version
-        </a>{" "}
-        of this page.
-      </p>
-    </div>
-  )
+  diffInDays > 0 ||
+    (true && (
+      <div
+        dir="ltr"
+        class="mx-2 mb-8 w-full rounded-lg bg-t3-purple-200/50 p-4 font-medium dark:bg-t3-purple-200/10"
+      >
+        <p>
+          Attention: This page is{" "}
+          <span class="font-extrabold">
+            {diffInDays} {diffInDays === 1 ? "day" : "days"}
+          </span>
+          older than the English version and might be outdated. If you're a
+          native speaker of this language and would like to contribute to the
+          project, please consider updating this page to match the latest
+          English version.
+        </p>
+        <p class="mt-3">
+          You can also{" "}
+          <a class="text-t3-purple-400" href={engHref}>
+            {JSON.stringify(engHref)}
+            view the English version
+          </a>{" "}
+          of this page.
+        </p>
+      </div>
+    ))
 }

--- a/www/src/components/docs/outdatedDocsBanner.astro
+++ b/www/src/components/docs/outdatedDocsBanner.astro
@@ -54,8 +54,8 @@ Astro.response.headers.set("Cache-Control", `s-max-age=${ONE_WEEK}`);
 ---
 
 {
-  diffInDays > 0 ||
-    (true && (
+  (diffInDays > 0 ||
+    true) && (
       <div
         dir="ltr"
         class="mx-2 mb-8 w-full rounded-lg bg-t3-purple-200/50 p-4 font-medium dark:bg-t3-purple-200/10"

--- a/www/src/components/docs/outdatedDocsBanner.astro
+++ b/www/src/components/docs/outdatedDocsBanner.astro
@@ -9,7 +9,12 @@ const { path } = Astro.props;
 const [_1, _2, _3, ...rest] = path.split("/");
 
 const englishPath = `src/pages/en/${rest.join("/")}`;
-const engHref = `/en/${rest}`.replace(/(.*)\.[^.]+$/, "");
+const engHrefMatch = `/en/${rest}`.match(/(.*)\.[^.]+$/);
+if (!engHrefMatch) {
+  throw new Error("No english path found");
+}
+
+const engHref = engHrefMatch[1];
 
 const url = `https://api.github.com/repos/t3-oss/create-t3-app/commits?path=www/${path}&per_page=1`;
 const engUrl = `https://api.github.com/repos/t3-oss/create-t3-app/commits?path=www/${englishPath}&per_page=1`;

--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -28,6 +28,7 @@ export const KNOWN_LANGUAGES = {
   en: "🇺🇸 English",
   // Add more languages here
   // sv: "🇸🇪 Svenska",
+  ru: "🇷🇺 Русский",
 } as const;
 export type KnownLanguageCode = keyof typeof KNOWN_LANGUAGES;
 
@@ -92,6 +93,9 @@ export const SIDEBAR: Sidebar = {
       { text: "Docker", link: "en/deployment/docker" },
     ],
   },
+  ru: {
+    Deployment: [{ text: "Vercel", link: "ru/deployment/vercel" }],
+  },
 };
 export const SIDEBAR_HEADER_MAP: Record<
   Exclude<KnownLanguageCode, "en">,
@@ -103,4 +107,9 @@ export const SIDEBAR_HEADER_MAP: Record<
   //   Usage: "Användarguide",
   //   Deployment: "Deployment",
   // },
+  ru: {
+    "Create T3 App": "Создать T3 App",
+    Usage: "Использование",
+    Deployment: "Развертывание",
+  },
 };

--- a/www/src/pages/ru/deployment/vercel.md
+++ b/www/src/pages/ru/deployment/vercel.md
@@ -1,0 +1,63 @@
+---
+title: Vercel
+description: Развертывание на Vercel
+layout: ../../../layouts/docs.astro
+lang: ru
+---
+
+Мы рекомендуем развертывать ваше приложение на [Vercel](https://vercel.com/?utm_source=t3-oss&utm_campaign=oss). Он позволяет очень легко развертывать Next.js приложения.
+
+## Конфигурация проекта
+
+Скорее всего Vercel настроит вашу команду сборки и каталог публикации автоматически. Однако вы также можете уточнить эту информацию вместе с другими конфигурациями, создав файл [`vercel.json`](https://vercel.com/docs/project-configuration) и включив в него следующие команды:
+
+```json
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install"
+}
+```
+
+## Использование Vercel Dashboard
+
+1. После отправки вашего кода в репозиторий GitHub зарегистрируйтесь на [Vercel](https://vercel.com/?utm_source=t3-oss&utm_campaign=oss) с GitHub и нажмите **Add New Project**.
+
+![Новый проект на Vercel](/images/vercel-new-project.webp)
+
+2. Импортируйте репозиторий GitHub с вашим проектом.
+
+![Импортируйте репозитоpий](/images/vercel-import-project.webp)
+
+3. Добавьте ваши переменные среды.
+
+![Добавьте ваши переменные среды](/images/vercel-env-vars.webp)
+
+4. Нажмите **Deploy**. Теперь каждый раз, когда вы отправляете изменение в ваш репозиторий, Vercel автоматически переразвернет ваше приложение!
+
+## Использование Vercel CLI
+
+Для того, чтобы развернуть приложение из командной строки, вам сначала нужно [установить Vercel CLI глобально](https://vercel.com/docs/cli#installing-vercel-cli).
+
+```bash
+npm i -g vercel
+```
+
+Запустите команду [`vercel`](https://vercel.com/docs/cli/deploying-from-cli), чтобы развернуть ваш проект.
+
+```bash
+vercel
+```
+
+Добавьте `--env DATABASE_URL=YOUR_DATABASE_URL_HERE` для переменных среды, таких как строка подключения к базе данных. Используйте `--yes`, если хотите пропустить вопросы развертывания и дать ответ по умолчанию для каждого.
+
+```bash
+vercel --env DATABASE_URL=YOUR_DATABASE_URL_HERE --yes
+```
+
+После первого развертывания эта команда развернет изменения в ветку предварительного просмотра. Вам нужно будет включить `--prod`, чтобы отправить изменения напрямую на сайт в продакшене для будущих развертываний.
+
+```bash
+vercel --prod
+```


### PR DESCRIPTION
Closes #907

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

1. engHref now is gotten through the regex match()


---

## Screenshots

Demonstration that href is correct
![image](https://user-images.githubusercontent.com/34962307/205371238-c94963ae-3ab9-4ce0-a5fc-e6b5484c6443.png)

💯
