### PR TITLE
fix: breadcrumbs translations

### DIFF
--- a/www/src/components/docs/breadCrumbs.tsx
+++ b/www/src/components/docs/breadCrumbs.tsx
@@ -1,4 +1,4 @@
-import { SIDEBAR } from "../../config";
+import { SIDEBAR, SIDEBAR_HEADER_MAP, type OuterHeaders } from "../../config";
 import { getLanguageFromURL } from "../../languages";
 
 type SlugType = "" | "usage" | "deployment";
@@ -29,6 +29,11 @@ export default function BreadCrumbs() {
     return actualEntries?.find((entry) => entry.link === link)?.text;
   };
 
+  const getHeaderName = (header: OuterHeaders) => {
+    if (lang === "en") return header;
+    return SIDEBAR_HEADER_MAP[lang][header];
+  };
+
   const breadcrumbs = window.location.href
     .split("/")
     .slice(window.location.href.split("/").length > 5 ? -2 : -1)
@@ -39,9 +44,12 @@ export default function BreadCrumbs() {
         .join("/");
       return {
         href,
+        key: crumb,
         text:
-          getPathNameFromLink(href.slice(href.indexOf("en"))) ||
-          crumb[0]?.toUpperCase() + crumb.slice(1),
+          getPathNameFromLink(href.slice(href.indexOf(lang))) ||
+          getHeaderName(
+            (crumb[0]?.toUpperCase() + crumb.slice(1)) as OuterHeaders,
+          ),
       };
     });
 
@@ -61,12 +69,12 @@ export default function BreadCrumbs() {
       <svg width="16" height="16" viewBox="0 0 24 24">
         <path
           fill="currentColor"
-          fill-rule="evenodd"
+          fillRule="evenodd"
           d="m9.005 4l8 8l-8 8L7 18l6.005-6L7 6z"
         />
       </svg>
       {breadcrumbs.map((crumb, index) => (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2" key={crumb.key}>
           <a
             href={crumb.href}
             className="rounded-lg border bg-t3-purple-200/50 p-1 hover:bg-t3-purple-200/75 hover:no-underline dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50"
@@ -77,7 +85,7 @@ export default function BreadCrumbs() {
             <svg width="16" height="16" viewBox="0 0 24 24">
               <path
                 fill="currentColor"
-                fill-rule="evenodd"
+                fillRule="evenodd"
                 d="m9.005 4l8 8l-8 8L7 18l6.005-6L7 6z"
               />
             </svg>

--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -43,7 +43,7 @@ export const ALGOLIA = {
   apiKey: "892c4647b96fe1b3d0b7d8de1c5b5e40",
 };
 
-type OuterHeaders = "Create T3 App" | "Usage" | "Deployment";
+export type OuterHeaders = "Create T3 App" | "Usage" | "Deployment";
 export type Sidebar = {
   [TCode in KnownLanguageCode]: {
     [THeader in OuterHeaders]?: {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Made breadcrumbs work on non-English pages. Translations are pulled from `config.ts` file.
- Fixed React warnings in `breadCrumbs.tsx`

![image](https://user-images.githubusercontent.com/35634442/205464845-9ec70ba0-f662-4313-b01d-07dbf19edfd0.png)

---

## Screenshots

**BEFORE**

![image](https://user-images.githubusercontent.com/35634442/205464689-68400a09-2e18-4e82-ba8b-7f5cd07b6b8c.png)

**AFTER**

![image](https://user-images.githubusercontent.com/35634442/205464624-d316c17c-8a65-4971-a11a-acad4a6c4512.png)


💯
