### PR TITLE
fix: (temp) pin next-auth

### DIFF
--- a/.changeset/few-mangos-clean.md
+++ b/.changeset/few-mangos-clean.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+temporarily pin next-auth

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -22,8 +22,10 @@ export type AvailablePackages = typeof availablePackages[number];
  */
 export const dependencyVersionMap = {
   // NextAuth.js
-  "next-auth": "^4.15.1",
-  "@next-auth/prisma-adapter": "^1.0.4",
+  // FIXME: next-auth and @next-auth/prisma-adapter pinned temporarily due to breaking changes
+  // need to fix the actual problem and then unpin
+  "next-auth": "4.17.0",
+  "@next-auth/prisma-adapter": "1.0.5",
 
   // Prisma
   prisma: "^4.5.0",


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Pins next-auth to 4.17.0 and @next-auth/prisma-adapter to 1.0.5 until we fix the problems that we have due to breaking changes in 4.18

💯
