### PR TITLE
chore(ci): prevent rate-limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,5 +169,5 @@ jobs:
 
       - run: pnpm run --filter=www check
       - run: pnpm turbo --filter=www build
-        env:
-          PUBLIC_GITHUB_TOKEN: ${{ secrets.PUBLIC_GITHUB_TOKEN }}
+        # env:
+        #   PUBLIC_GITHUB_TOKEN: ${{ secrets.PUBLIC_GITHUB_TOKEN }}


### PR DESCRIPTION
Seems like we make too many requests during CI for the token to handle:

![image](https://user-images.githubusercontent.com/51714798/205486961-4bf274af-2eca-4f7a-aa0c-d4d57e5b2686.png)


Removing the token will make sure we don't fetch at all