### PR TITLE
fix(docs): show pagination on non-EN pages

### DIFF
--- a/www/src/components/docs/pagination.astro
+++ b/www/src/components/docs/pagination.astro
@@ -1,6 +1,6 @@
 ---
+import { getLanguageFromURL } from "../../languages";
 import { paginate } from "../../utils/pagination";
-const langCode = "en";
 
 const currentPage = Astro.url.pathname;
 const hasTrailing = currentPage.endsWith("/");
@@ -9,6 +9,7 @@ const currentPageMatch = currentPage.slice(
   hasTrailing ? -1 : currentPage.length,
 );
 
+const langCode = getLanguageFromURL(currentPage);
 const { next, prev } = paginate(langCode, currentPageMatch);
 ---
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The language code was hardcoded to `EN` before in pagination. Updated the file so that pagination works for all languages now.

---

## Screenshots

- Prod 

![image](https://user-images.githubusercontent.com/89210438/205489706-9291d756-a616-424f-afb6-5915c153f13a.png)

- Now

![image](https://user-images.githubusercontent.com/89210438/205489717-4628fd7e-a06e-435b-9196-311f6a2e1500.png)

💯
