### PR TITLE
refactor(www): consistent spacing in mobile layout

### DIFF
--- a/www/src/components/docs/breadCrumbs.tsx
+++ b/www/src/components/docs/breadCrumbs.tsx
@@ -54,7 +54,7 @@ export default function BreadCrumbs() {
     });
 
   return (
-    <div className="mb-4 flex items-center gap-2 px-2 text-sm">
+    <div className="mb-4 flex items-center gap-2 px-4 text-sm">
       <a
         href="/"
         className="rounded-lg border bg-t3-purple-200/50 p-1 hover:bg-t3-purple-200/75 hover:no-underline dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50"

--- a/www/src/components/docs/outdatedDocsBanner.astro
+++ b/www/src/components/docs/outdatedDocsBanner.astro
@@ -9,7 +9,7 @@ const { path } = Astro.props;
 const [_1, _2, _3, ...rest] = path.split("/");
 
 const englishPath = `src/pages/en/${rest.join("/")}`;
-const engHref = `/en/${rest}`.replace(/(.*)\.[^.]+$/, "");
+const engHref = `/en/${rest.join("/").replace(/\.[^/.]+$/, "")}`;
 
 const url = `https://api.github.com/repos/t3-oss/create-t3-app/commits?path=www/${path}&per_page=1`;
 const engUrl = `https://api.github.com/repos/t3-oss/create-t3-app/commits?path=www/${englishPath}&per_page=1`;
@@ -52,7 +52,7 @@ Astro.response.headers.set("Cache-Control", `s-max-age=${ONE_WEEK}`);
   diffInDays > 0 && (
     <div
       dir="ltr"
-      class="mx-2 mb-8 rounded-lg bg-t3-purple-200/50 p-4 font-medium dark:bg-t3-purple-200/10 lg:w-full"
+      class="mx-4 mb-4 rounded-lg bg-t3-purple-200/50 p-4 font-medium dark:bg-t3-purple-200/10 lg:w-full"
     >
       <p>
         Attention: This page is{" "}

--- a/www/src/components/docs/pageContent.astro
+++ b/www/src/components/docs/pageContent.astro
@@ -29,7 +29,7 @@ const [_1, _2, lang] = path.split("/");
   <section class="w-full">
     <h1
       id="overview"
-      class="mb-4 px-3 text-3xl font-extrabold dark:text-t3-purple-100"
+      class="mb-4 px-4 text-3xl font-extrabold dark:text-t3-purple-100"
     >
       <a
         href="#overview"

--- a/www/src/components/navigation/OnThisPageLinks.tsx
+++ b/www/src/components/navigation/OnThisPageLinks.tsx
@@ -71,7 +71,7 @@ export default function OnThisPageLinks({
   }, [headings, title]);
 
   return (
-    <div className="sticky inset-x-0 top-20 z-[2] block w-full bg-default px-3 py-4 lg:hidden">
+    <div className="sticky inset-x-0 top-20 z-[2] block w-full bg-default px-4 pb-2 lg:hidden">
       <Menu>
         {({ open }) => (
           <div className="relative w-full">


### PR DESCRIPTION
Also closes #907

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- all the elements in docs pages have consistent horizontal padding.
- fixed the broken regex for getting `en` link in outdated page banner.

---

## Screenshots

![image](https://user-images.githubusercontent.com/68690233/205503203-dabde512-f1ac-4e88-91b2-f19acb347196.png)

💯