### PR TITLE
docs: "on this page" styles

### DIFF
--- a/www/src/components/navigation/OnThisPageLinks.tsx
+++ b/www/src/components/navigation/OnThisPageLinks.tsx
@@ -76,7 +76,7 @@ export default function OnThisPageLinks({
         {({ open }) => (
           <div className="relative w-full">
             <div className="">
-              <Menu.Button className="inline-flex cursor-pointer items-center whitespace-nowrap rounded-md border-2 bg-t3-purple-200/50 px-2 py-1.5 text-sm font-medium hover:bg-t3-purple-200/75 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50">
+              <Menu.Button className="text-md inline-flex cursor-pointer items-center whitespace-nowrap rounded-md border-2 bg-t3-purple-200/50 px-3 py-2 font-medium hover:bg-t3-purple-200/75 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50">
                 On this page
                 <span className="ml-1.5">
                   <svg
@@ -102,7 +102,7 @@ export default function OnThisPageLinks({
             </div>
             <Menu.Items
               as="ul"
-              className="t3-scrollbar absolute top-full z-10 mt-3 max-h-80 w-full overflow-y-auto rounded-md border-2 border-primary bg-default py-1.5 shadow-md dark:border-t3-purple-200/20 dark:bg-default"
+              className="t3-scrollbar absolute top-full z-10 mt-3 max-h-[45vh] w-full overflow-y-auto rounded-md border-2 border-primary bg-default py-1.5 shadow-md dark:border-t3-purple-200/20 dark:bg-default"
             >
               {headingWithIsVisible.map((heading) => (
                 <li key={heading.slug} className="w-full">
@@ -110,8 +110,8 @@ export default function OnThisPageLinks({
                     {({ active }) => (
                       <a
                         className={clsx(
-                          "line-clamp-1 block w-full py-1 text-sm text-t3-purple-800 transition-colors hover:bg-t3-purple-300/20 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:bg-t3-purple-300/10 dark:hover:text-t3-purple-100",
-                          `pl-${heading.depth * 2 - 2}`,
+                          "line-clamp-1 text-md block w-full py-2 text-t3-purple-800 transition-colors hover:bg-t3-purple-300/20 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:bg-t3-purple-300/10 dark:hover:text-t3-purple-50",
+                          heading.depth === 2 ? "pl-3" : "pl-8",
                           {
                             "bg-t3-purple-300/20 text-t3-purple-400 underline dark:bg-t3-purple-300/10 dark:text-t3-purple-100":
                               active,

--- a/www/src/components/navigation/tableOfContents.astro
+++ b/www/src/components/navigation/tableOfContents.astro
@@ -32,10 +32,10 @@ const isRtl = getIsRtlFromUrl(pathname);
         return (
           <li
             class={clsx(
-              "w-full list-none border-t3-purple-300/20 p-1 text-sm transition-colors duration-300 hover:border-t3-purple-300/50",
+              "w-full list-none border-t3-purple-300/20 p-1 text-sm transition-colors duration-300 hover:border-t3-purple-300/50 [border-inline-start-2]",
               isRtl
-                ? `border-r-2 pr-${depth * 2 - 2}`
-                : `border-l-2 pl-${depth * 2 - 2}`,
+                ? ["border-r-2", depth === 2 ? "pr-2" : "pr-4"]
+                : ["border-l-2", depth === 2 ? "pl-2" : "pl-4"],
             )}
           >
             <a


### PR DESCRIPTION
Closes #925

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- fix "on this page" indentation in both desktop and mobile - was broken due to a bug (not sure if astro/react/clsx/tailwind) where some classes weren't being applied
- mobile: made each item a bit bigger. each tough target is now 40px high, which is the minimum that a touch target which is surrounded by other touch targets should ever be.
-mobile: made the entire menu a bit bigger when it has many items in it

---

## Screenshots

before: see #925 

after:

phone 14 size
<img width="434" alt="image" src="https://user-images.githubusercontent.com/8353666/205739970-45001653-282a-473e-a940-3432038200c2.png">
<img width="430" alt="image" src="https://user-images.githubusercontent.com/8353666/205740036-d88b3dd2-92c1-429d-ae61-d19dee6f021f.png">

ipad air size
<img width="848" alt="image" src="https://user-images.githubusercontent.com/8353666/205740123-27613442-b92a-4b93-91df-ce7f484a2a56.png">
<img width="854" alt="image" src="https://user-images.githubusercontent.com/8353666/205740198-f9ae35b2-ef7a-440f-8625-da494dee18e8.png">

computer
<img width="403" alt="image" src="https://user-images.githubusercontent.com/8353666/205739805-60fb6b3a-f0e3-436d-82da-0d10e2447226.png">


💯
