### PR TITLE
docs: remove flags from languages

### DIFF
--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -25,10 +25,10 @@ export type Frontmatter = {
 };
 
 export const KNOWN_LANGUAGES = {
-  en: "🇺🇸 English",
+  en: "English",
   // Add more languages here
-  // sv: "🇸🇪 Svenska",
-  ru: "🇷🇺 Русский",
+  // sv: "Svenska",
+  ru: "Русский",
 } as const;
 export type KnownLanguageCode = keyof typeof KNOWN_LANGUAGES;
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Removed flags from languages in docs
- The language select menu looks a bit less nice, but it's a worthwhile tradeoff imo

## Reasoning

There is no 1:1 correlation between countries and languages, and using flags to represent languages can imply taking sides in various political conflicts.

Examples:
- Russian is spoken in both Russia and Ukraine
- Arabic is spoken in many countries, and some countries where Arabic is spoken also have large populations of speakers of other languages
- We only have one Portuguese translation, which will be used by people in both Brazil and Portugal
- What language is associated with this flag: 🇮🇳?
- etc

Examples of other docs that don't use flags to denote languages:
- [React](https://reactjs.org/languages)
- [Vue](https://vuejs.org/guide/introduction.html)
- [Astro](https://docs.astro.build/en/getting-started/)
- [Angular](https://angular.io/guide/localized-documentation)

Happy do discuss this in the comments, but I strongly believe that it's the right way to go.

## Screenshots

<img width="164" alt="image" src="https://user-images.githubusercontent.com/8353666/205984424-b91455c3-3670-4bda-bccd-2628883a71df.png">

💯

