### PR TITLE
fix: breaking error caused by unstable_getServerSession changes in next-auth 4.18

### DIFF
--- a/.changeset/lucky-kangaroos-tickle.md
+++ b/.changeset/lucky-kangaroos-tickle.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix next-auth error

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -22,10 +22,8 @@ export type AvailablePackages = typeof availablePackages[number];
  */
 export const dependencyVersionMap = {
   // NextAuth.js
-  // FIXME: next-auth and @next-auth/prisma-adapter pinned temporarily due to breaking changes
-  // need to fix the actual problem and then unpin
-  "next-auth": "4.17.0",
-  "@next-auth/prisma-adapter": "1.0.5",
+  "next-auth": "^4.18.0",
+  "@next-auth/prisma-adapter": "^1.0.5",
 
   // Prisma
   prisma: "^4.5.0",

--- a/cli/template/addons/next-auth/get-server-auth-session.ts
+++ b/cli/template/addons/next-auth/get-server-auth-session.ts
@@ -11,5 +11,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, authOptions);
+  // next-auth 4.18.0 introduced a breaking change to unstable_getServerSession
+  // FIXME: find a better solution than spreading authOptions into a new object
+  return await unstable_getServerSession(ctx.req, ctx.res, { ...authOptions });
 };

--- a/www/src/pages/en/usage/next-auth.md
+++ b/www/src/pages/en/usage/next-auth.md
@@ -78,7 +78,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, nextAuthOptions);
+  return await unstable_getServerSession(ctx.req, ctx.res, { ...nextAuthOptions });
 };
 ```
 

--- a/www/src/pages/en/usage/next-auth.md
+++ b/www/src/pages/en/usage/next-auth.md
@@ -78,7 +78,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, { ...nextAuthOptions });
+  return await unstable_getServerSession(ctx.req, ctx.res, { ...authOptions });
 };
 ```
 

--- a/www/src/pages/ru/usage/next-auth.md
+++ b/www/src/pages/ru/usage/next-auth.md
@@ -78,7 +78,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, nextAuthOptions);
+  return await unstable_getServerSession(ctx.req, ctx.res, { ...nextAuthOptions });
 };
 ```
 

--- a/www/src/pages/ru/usage/next-auth.md
+++ b/www/src/pages/ru/usage/next-auth.md
@@ -78,7 +78,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, { ...nextAuthOptions });
+  return await unstable_getServerSession(ctx.req, ctx.res, { ...authOptions });
 };
 ```
 


### PR DESCRIPTION
Closes https://github.com/t3-oss/create-t3-app/issues/911

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- spread authOptions into a new object to fix unstable_getServerSession error
- this is probably not the best possible solution so added a FIXME
- unpin next-auth
- update docs & fix outdated naming (`nextAuthOptions` instead of `authOptions`)

---

## Screenshots

<img width="2559" alt="image" src="https://user-images.githubusercontent.com/8353666/205993204-0866dda5-a817-4c2a-8544-7764b58b9c9e.png">

💯
