### PR TITLE
fix: use next-auth 4.18.3 and undo hotfix

### DIFF
--- a/.changeset/hip-apples-hunt.md
+++ b/.changeset/hip-apples-hunt.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+use next-auth 4.18.3 and undo hotfix

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -22,7 +22,7 @@ export type AvailablePackages = typeof availablePackages[number];
  */
 export const dependencyVersionMap = {
   // NextAuth.js
-  "next-auth": "^4.18.0",
+  "next-auth": "^4.18.3",
   "@next-auth/prisma-adapter": "^1.0.5",
 
   // Prisma

--- a/cli/template/addons/next-auth/get-server-auth-session.ts
+++ b/cli/template/addons/next-auth/get-server-auth-session.ts
@@ -11,7 +11,5 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  // next-auth 4.18.0 introduced a breaking change to unstable_getServerSession
-  // FIXME: find a better solution than spreading authOptions into a new object
-  return await unstable_getServerSession(ctx.req, ctx.res, { ...authOptions });
+  return await unstable_getServerSession(ctx.req, ctx.res, authOptions);
 };

--- a/www/src/pages/en/usage/next-auth.md
+++ b/www/src/pages/en/usage/next-auth.md
@@ -78,7 +78,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, { ...authOptions });
+  return await unstable_getServerSession(ctx.req, ctx.res, authOptions);
 };
 ```
 

--- a/www/src/pages/ru/usage/next-auth.md
+++ b/www/src/pages/ru/usage/next-auth.md
@@ -78,7 +78,7 @@ export const getServerAuthSession = async (ctx: {
   req: GetServerSidePropsContext["req"];
   res: GetServerSidePropsContext["res"];
 }) => {
-  return await unstable_getServerSession(ctx.req, ctx.res, { ...authOptions });
+  return await unstable_getServerSession(ctx.req, ctx.res, authOptions);
 };
 ```
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- upgrade next-auth to `^4.18.3`
- undo the authOptions spreading hotfix
- update docs accordingly

References:
https://github.com/nextauthjs/next-auth/pull/5973
https://github.com/t3-oss/create-t3-app/pull/932#issuecomment-1341907346

---

## Screenshots

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8353666/206415432-6b52c120-d91c-4f1b-baab-8a75cd41168f.png">


💯
