### PR TITLE
fix: rtl breadcrumbs, "on this page", env var folder structure

### DIFF
--- a/www/src/components/docs/breadCrumbs.tsx
+++ b/www/src/components/docs/breadCrumbs.tsx
@@ -1,13 +1,18 @@
 import clsx from "clsx";
-import { SIDEBAR, SIDEBAR_HEADER_MAP, type OuterHeaders } from "../../config";
-import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
+import {
+  KnownLanguageCode,
+  SIDEBAR,
+  SIDEBAR_HEADER_MAP,
+  type OuterHeaders,
+} from "../../config";
+import { getIsRtlFromLangCode, getLanguageFromURL } from "../../languages";
 
 type SlugType = "" | "usage" | "deployment";
 type Entry = { text: string; link: string };
 
 export default function BreadCrumbs() {
   const lang = getLanguageFromURL(window.location.href);
-  const isRtl = getIsRtlFromUrl(window.location.href);
+  const isRtl = getIsRtlFromLangCode((lang ?? "en") as KnownLanguageCode);
   const slugToEntryPath = (slug: SlugType) => {
     switch (slug) {
       case "":

--- a/www/src/components/docs/breadCrumbs.tsx
+++ b/www/src/components/docs/breadCrumbs.tsx
@@ -1,11 +1,13 @@
+import clsx from "clsx";
 import { SIDEBAR, SIDEBAR_HEADER_MAP, type OuterHeaders } from "../../config";
-import { getLanguageFromURL } from "../../languages";
+import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
 
 type SlugType = "" | "usage" | "deployment";
 type Entry = { text: string; link: string };
 
 export default function BreadCrumbs() {
   const lang = getLanguageFromURL(window.location.href);
+  const isRtl = getIsRtlFromUrl(window.location.href);
   const slugToEntryPath = (slug: SlugType) => {
     switch (slug) {
       case "":
@@ -66,13 +68,7 @@ export default function BreadCrumbs() {
           />
         </svg>
       </a>
-      <svg width="16" height="16" viewBox="0 0 24 24">
-        <path
-          fill="currentColor"
-          fillRule="evenodd"
-          d="m9.005 4l8 8l-8 8L7 18l6.005-6L7 6z"
-        />
-      </svg>
+      <BreadCrumbsArrow isRtl={isRtl} />
       {breadcrumbs.map((crumb, index) => (
         <div className="flex items-center gap-2" key={crumb.key}>
           <a
@@ -81,17 +77,26 @@ export default function BreadCrumbs() {
           >
             {crumb.text}
           </a>
-          {index < breadcrumbs.length - 1 && (
-            <svg width="16" height="16" viewBox="0 0 24 24">
-              <path
-                fill="currentColor"
-                fillRule="evenodd"
-                d="m9.005 4l8 8l-8 8L7 18l6.005-6L7 6z"
-              />
-            </svg>
-          )}
+          {index < breadcrumbs.length - 1 && <BreadCrumbsArrow isRtl={isRtl} />}
         </div>
       ))}
     </div>
+  );
+}
+
+function BreadCrumbsArrow(props: { isRtl: boolean }) {
+  return (
+    <svg
+      className={clsx(props.isRtl && "rotate-180")}
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="m9.005 4l8 8l-8 8L7 18l6.005-6L7 6z"
+      />
+    </svg>
   );
 }

--- a/www/src/components/docs/pageContent.astro
+++ b/www/src/components/docs/pageContent.astro
@@ -1,10 +1,11 @@
 ---
 import type { MarkdownHeading } from "astro";
-import type { Frontmatter } from "../../config";
+import type { Frontmatter, KnownLanguageCode } from "../../config";
 import OutdatedDocsBanner from "./outdatedDocsBanner.astro";
 import BreadCrumbs from "./breadCrumbs";
 import Pagination from "./pagination.astro";
 import OnThisPageLinks from "../navigation/OnThisPageLinks";
+import { getIsRtlFromLangCode } from "../../languages";
 
 export interface Props {
   frontmatter: Frontmatter;
@@ -16,6 +17,7 @@ const { frontmatter, path, headings } = Astro.props;
 const title = frontmatter.title;
 
 const [_1, _2, lang] = path.split("/");
+const isRtl = getIsRtlFromLangCode((lang || "en") as KnownLanguageCode);
 ---
 
 <article id="article" class="flex w-full max-w-screen-lg flex-col">
@@ -25,6 +27,7 @@ const [_1, _2, lang] = path.split("/");
     client:media="(max-width: 1024px)"
     headings={headings}
     title={title}
+    isRtl={isRtl}
   />
   <section class="w-full">
     <h1

--- a/www/src/components/navigation/OnThisPageLinks.tsx
+++ b/www/src/components/navigation/OnThisPageLinks.tsx
@@ -6,11 +6,13 @@ import clsx from "clsx";
 type OnThisPageLinksProps = {
   headings: MarkdownHeading[];
   title: string;
+  isRtl: boolean;
 };
 
 export default function OnThisPageLinks({
   headings,
   title,
+  isRtl,
 }: OnThisPageLinksProps) {
   const memoedHeadings = useMemo(() => {
     // add isVisible flag in headers
@@ -76,28 +78,29 @@ export default function OnThisPageLinks({
         {({ open }) => (
           <div className="relative w-full">
             <div className="">
-              <Menu.Button className="text-md inline-flex cursor-pointer items-center whitespace-nowrap rounded-md border-2 bg-t3-purple-200/50 px-3 py-2 font-medium hover:bg-t3-purple-200/75 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50">
+              <Menu.Button className="text-md inline-flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border-2 bg-t3-purple-200/50 px-3 py-2 font-medium hover:bg-t3-purple-200/75 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50">
                 On this page
-                <span className="ml-1.5">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    strokeWidth={1.5}
-                    stroke="currentColor"
-                    className="h-3 w-3 sm:h-4 sm:w-4"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d={
-                        open
-                          ? "M19.5 8.25l-7.5 7.5-7.5-7.5"
-                          : "M8.25 4.5l7.5 7.5-7.5 7.5"
-                      }
-                    />
-                  </svg>
-                </span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className={clsx(
+                    "h-3 w-3 sm:h-4 sm:w-4",
+                    isRtl && "-scale-x-100",
+                  )}
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d={
+                      open
+                        ? "M19.5 8.25l-7.5 7.5-7.5-7.5"
+                        : "M8.25 4.5l7.5 7.5-7.5 7.5"
+                    }
+                  />
+                </svg>
               </Menu.Button>
             </div>
             <Menu.Items

--- a/www/src/components/navigation/OnThisPageLinks.tsx
+++ b/www/src/components/navigation/OnThisPageLinks.tsx
@@ -14,6 +14,8 @@ export default function OnThisPageLinks({
   title,
   isRtl,
 }: OnThisPageLinksProps) {
+  const isLtr = !isRtl;
+
   const memoedHeadings = useMemo(() => {
     // add isVisible flag in headers
     const headers = [
@@ -104,32 +106,35 @@ export default function OnThisPageLinks({
               </Menu.Button>
             </div>
             <Menu.Items
-              as="ul"
+              dir="ltr"
               className="t3-scrollbar absolute top-full z-10 mt-3 max-h-[45vh] w-full overflow-y-auto rounded-md border-2 border-primary bg-default py-1.5 shadow-md dark:border-t3-purple-200/20 dark:bg-default"
             >
-              {headingWithIsVisible.map((heading) => (
-                <li key={heading.slug} className="w-full">
-                  <Menu.Item>
-                    {({ active }) => (
-                      <a
-                        className={clsx(
-                          "line-clamp-1 text-md block w-full py-2 text-t3-purple-800 transition-colors hover:bg-t3-purple-300/20 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:bg-t3-purple-300/10 dark:hover:text-t3-purple-50",
-                          heading.depth === 2 ? "pl-3" : "pl-8",
-                          {
-                            "bg-t3-purple-300/20 text-t3-purple-400 underline dark:bg-t3-purple-300/10 dark:text-t3-purple-100":
-                              active,
-                            "bg-t3-purple-300/30 font-medium text-t3-purple-700 underline dark:bg-t3-purple-300/20 dark:text-t3-purple-100":
-                              heading.isVisible,
-                          },
-                        )}
-                        href={`#${heading.slug}`}
-                      >
-                        {heading.text}
-                      </a>
-                    )}
-                  </Menu.Item>
-                </li>
-              ))}
+              <ul dir={isLtr ? "ltr" : "rtl"}>
+                {headingWithIsVisible.map((heading) => (
+                  <li key={heading.slug} className="w-full">
+                    <Menu.Item>
+                      {({ active }) => (
+                        <a
+                          className={clsx(
+                            "line-clamp-1 text-md block w-full py-2 text-t3-purple-800 transition-colors hover:bg-t3-purple-300/20 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:bg-t3-purple-300/10 dark:hover:text-t3-purple-50",
+                            isLtr && (heading.depth === 2 ? "pl-3" : "pl-8"),
+                            isRtl && (heading.depth === 2 ? "pr-3" : "pr-8"),
+                            {
+                              "bg-t3-purple-300/20 text-t3-purple-400 underline dark:bg-t3-purple-300/10 dark:text-t3-purple-100":
+                                active,
+                              "bg-t3-purple-300/30 font-medium text-t3-purple-700 underline dark:bg-t3-purple-300/20 dark:text-t3-purple-100":
+                                heading.isVisible,
+                            },
+                          )}
+                          href={`#${heading.slug}`}
+                        >
+                          {heading.text}
+                        </a>
+                      )}
+                    </Menu.Item>
+                  </li>
+                ))}
+              </ul>
             </Menu.Items>
           </div>
         )}

--- a/www/src/languages.ts
+++ b/www/src/languages.ts
@@ -27,6 +27,10 @@ const rtlLanguages = [
 
 export function getIsRtlFromUrl(pathname: string) {
   const language = getLanguageFromURL(pathname);
+  return getIsRtlFromLangCode(language);
+}
+
+export function getIsRtlFromLangCode(language: KnownLanguageCode) {
   if (rtlLanguages.indexOf(language) !== -1) {
     return true;
   }

--- a/www/src/pages/ar/usage/env-variables.md
+++ b/www/src/pages/ar/usage/env-variables.md
@@ -10,11 +10,11 @@ dir: rtl
 
 📁 src/env
 
-┣ 📄 client.mjs
+┫ 📄 client.mjs
 
-┣ 📄 schema.mjs
+┫ 📄 schema.mjs
 
-┣ 📄 server.mjs
+┫ 📄 server.mjs
 
 قد يبدو محتوى هذه الملفات مخيفًا للوهلة الأولى ، لكن لا تقلق ، فهو ليس معقدًا كما يبدو. دعنا نلقي نظرة عليها واحدة تلو الأخرى ، ونسير خلال عملية إضافة environment variables إضافية.
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Fixes for RTL
- breadcrumbs arrows pointing the wrong way
- "on this page" arrow pointing the wrong way
- "on this page" popover having bad spacing and scrollbar on the wrong side
- env vars folder structure ┫character pointing the wrong way

---

## Screenshots

<img width="412" alt="image" src="https://user-images.githubusercontent.com/8353666/206565239-8bd195df-05ec-48f8-a623-3a014d97ff46.png">

<img width="407" alt="image" src="https://user-images.githubusercontent.com/8353666/206565325-c9dcc521-3b0a-4a47-a422-cc90e1349eba.png">

💯
