### PR TITLE
fix(docs): `On this page` button spacing

### DIFF
--- a/www/src/components/navigation/OnThisPageLinks.tsx
+++ b/www/src/components/navigation/OnThisPageLinks.tsx
@@ -71,7 +71,7 @@ export default function OnThisPageLinks({
   }, [headings, title]);
 
   return (
-    <div className="sticky inset-x-0 top-20 z-[2] block w-full bg-default px-4 pb-2 lg:hidden">
+    <div className="sticky inset-x-0 top-20 z-[2] block w-full bg-default px-4 pb-4 pt-2 lg:hidden">
       <Menu>
         {({ open }) => (
           <div className="relative w-full">


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The `On this page` button cuts off when the page is scrolled up on mobile.

- Before

![image](https://user-images.githubusercontent.com/89210438/206636485-47199ebf-52c3-4b5d-86b3-7a19a47eafc2.png)

- After

![image](https://user-images.githubusercontent.com/89210438/206636539-3b088a01-a417-463d-a43e-e022c2ff0c53.png)


---

💯
