### PR TITLE
fix(docs): Language selector showing `EN` as active language on `non-EN` pages

### DIFF
--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -1,7 +1,6 @@
 ---
 import * as CONFIG from "../../config";
-import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
-import clsx from "clsx";
+import { getIsRtlFromUrl } from "../../languages";
 
 export interface Props {
   editHref: string;
@@ -10,7 +9,6 @@ export interface Props {
 const { editHref } = Astro.props;
 const { pathname } = Astro.url;
 const isRtl = getIsRtlFromUrl(pathname);
-const isLangEN = getLanguageFromURL(pathname) === "en";
 ---
 
 <div
@@ -47,43 +45,7 @@ const isLangEN = getLanguageFromURL(pathname) === "en";
             ></path>
           </svg>
         </span>
-        <span> Edit this page</span>
-      </a>
-    </li>
-
-    <li
-      class={clsx(
-        "hidden text-t3-purple-800 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100",
-        isLangEN ? ["md:block"] : [""],
-      )}
-    >
-      <a
-        class="flex items-center gap-2"
-        href={"https://github.com/t3-oss/create-t3-app/blob/next/www/TRANSLATIONS.md"}
-        target="_blank"
-      >
-        <span>
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            role="img"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 88.6 77.3"
-            height="1.3em"
-            width="1.3em"
-            style="margin: -2px;"
-          >
-            <path
-              fill="currentColor"
-              d="M61,24.6h7.9l18.7,51.6h-7.7l-5.4-15.5H54.3l-5.6,15.5h-7.2L61,24.6z M72.6,55l-8-22.8L56.3,55H72.6z"
-            ></path>
-            <path
-              fill="currentColor"
-              d="M53.6,60.6c-10-4-16-9-22-14c0,0,1.3,1.3,0,0c-6,5-20,13-20,13l-4-6c8-5,10-6,19-13c-2.1-1.9-12-13-13-19h8          c4,9,10,14,10,14c10-8,10-19,10-19h8c0,0-1,13-12,24l0,0c5,5,10,9,19,13L53.6,60.6z M1.6,16.6h56v-8h-23v-7h-9v7h-24V16.6z"
-            ></path>
-          </svg>
-        </span>
-        <span> Translate this page</span>
+        <span>Edit this page</span>
       </a>
     </li>
 

--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -69,8 +69,8 @@ const isLangEN = getLanguageFromURL(pathname) === "en";
             role="img"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 88.6 77.3"
-            height="1.24em"
-            width="1.24em"
+            height="1.3em"
+            width="1.3em"
             style="margin: -2px;"
           >
             <path

--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -1,6 +1,7 @@
 ---
 import * as CONFIG from "../../config";
-import { getIsRtlFromUrl } from "../../languages";
+import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
+import clsx from "clsx";
 
 export interface Props {
   editHref: string;
@@ -9,6 +10,7 @@ export interface Props {
 const { editHref } = Astro.props;
 const { pathname } = Astro.url;
 const isRtl = getIsRtlFromUrl(pathname);
+const isLangEN = getLanguageFromURL(pathname) === "en";
 ---
 
 <div
@@ -45,7 +47,43 @@ const isRtl = getIsRtlFromUrl(pathname);
             ></path>
           </svg>
         </span>
-        <span>Edit this page</span>
+        <span> Edit this page</span>
+      </a>
+    </li>
+
+    <li
+      class={clsx(
+        "hidden text-t3-purple-800 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100",
+        isLangEN ? ["md:block"] : [""],
+      )}
+    >
+      <a
+        class="flex items-center gap-2"
+        href={"https://github.com/t3-oss/create-t3-app/blob/next/www/TRANSLATIONS.md"}
+        target="_blank"
+      >
+        <span>
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 88.6 77.3"
+            height="1.24em"
+            width="1.24em"
+            style="margin: -2px;"
+          >
+            <path
+              fill="currentColor"
+              d="M61,24.6h7.9l18.7,51.6h-7.7l-5.4-15.5H54.3l-5.6,15.5h-7.2L61,24.6z M72.6,55l-8-22.8L56.3,55H72.6z"
+            ></path>
+            <path
+              fill="currentColor"
+              d="M53.6,60.6c-10-4-16-9-22-14c0,0,1.3,1.3,0,0c-6,5-20,13-20,13l-4-6c8-5,10-6,19-13c-2.1-1.9-12-13-13-19h8          c4,9,10,14,10,14c10-8,10-19,10-19h8c0,0-1,13-12,24l0,0c5,5,10,9,19,13L53.6,60.6z M1.6,16.6h56v-8h-23v-7h-9v7h-24V16.6z"
+            ></path>
+          </svg>
+        </span>
+        <span> Translate this page</span>
       </a>
     </li>
 

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -1,6 +1,6 @@
 ---
 import clsx from "clsx";
-import { getIsRtlFromUrl } from "../../languages";
+import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
 import GithubIcon from "./githubIcon.astro";
 import Search from "./Search";
 import LanguageSelect from "./LanguageSelect";
@@ -17,6 +17,7 @@ const isLtr = !isRtl;
 const isLanding = pathname === "/" || !!Astro.props.isNotFound;
 const hasTrailing = pathname.endsWith("/");
 const currentPage = pathname.slice(0, hasTrailing ? -1 : pathname.length);
+const langCode = getLanguageFromURL(pathname);
 
 const navbarLinks: Array<{ href: string; label: string }> = [
   {
@@ -84,7 +85,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
     </div>
     <div class="flex flex-grow items-center justify-end gap-4">
       <GithubIcon />
-      {!isLanding && <LanguageSelect language={"en"} client:load />}
+      {!isLanding && <LanguageSelect language={langCode} client:load />}
       <div
         class={clsx("text-center", {
           hidden: isLanding,


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The active language selector was hard coded before to `EN`. Updated the code so that the active option syncs with the current language.

## Screenshots

- Before

![image](https://user-images.githubusercontent.com/89210438/206656431-2cca9257-a51f-4167-ae39-f913eacf6bc0.png)

- After

![image](https://user-images.githubusercontent.com/89210438/206656505-0f8802e0-8d5c-43ef-9916-85d4cffa3fab.png)


💯
