### PR TITLE
fix: docs translation date diff

### DIFF
--- a/www/src/components/docs/outdatedDocsBanner.astro
+++ b/www/src/components/docs/outdatedDocsBanner.astro
@@ -28,8 +28,7 @@ async function getCommitDiff() {
       : new Date();
 
     const diffInDays = Math.round(
-      Math.abs(thisLangDate.getTime() - englishDate.getTime()) /
-        (1000 * 3600 * 24),
+      englishDate.getTime() - thisLangDate.getTime() / (1000 * 3600 * 24),
     );
     return diffInDays;
   } catch (e) {

--- a/www/src/components/docs/outdatedDocsBanner.astro
+++ b/www/src/components/docs/outdatedDocsBanner.astro
@@ -28,7 +28,7 @@ async function getCommitDiff() {
       : new Date();
 
     const diffInDays = Math.round(
-      englishDate.getTime() - thisLangDate.getTime() / (1000 * 3600 * 24),
+      (englishDate.getTime() - thisLangDate.getTime()) / (1000 * 3600 * 24),
     );
     return diffInDays;
   } catch (e) {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- fixes the "this is x days older than the english version" message being incorrect
    - it was using the absolute value of the difference in age, ie the foreign version was ALWAYS older

---

## Screenshots

### Current ages: (using "Folder Structure" and "FAQ" as examples as one is newer in English, one in Portuguese

en:
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/8353666/206905686-4716c192-c2b2-4fff-94b4-c9dbddcb5ca9.png">


pt:
<img width="1235" alt="image" src="https://user-images.githubusercontent.com/8353666/206905700-bd266222-ba8c-4847-a54b-2179b8e7415d.png">

### Before
<img width="1045" alt="image" src="https://user-images.githubusercontent.com/8353666/206905739-43605187-c2cd-4455-bcee-008da6c2facf.png">

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/8353666/206905757-7bf68393-8a4f-4346-8103-203c03273fbf.png">


### After
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/8353666/206905779-b0eabbc6-cf86-4697-a1c8-e1dd8c1f440d.png">

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/8353666/206905788-62f9e45c-c347-495d-b066-76b2bf584045.png">


💯
