### PR TITLE
fix: breadcrumbs fix

### DIFF
--- a/www/src/components/docs/breadCrumbs.tsx
+++ b/www/src/components/docs/breadCrumbs.tsx
@@ -41,19 +41,19 @@ export default function BreadCrumbs() {
     return SIDEBAR_HEADER_MAP[lang][header];
   };
 
-  const breadcrumbs = window.location.href
+  const breadcrumbs = window.location.pathname
     .split("/")
-    .slice(window.location.href.split("/").length > 5 ? -2 : -1)
+    .slice(window.location.pathname.split("/").length > 3 ? -2 : -1)
     .map((crumb) => {
-      const href = window.location.href
+      const path = window.location.pathname
         .split("/")
-        .slice(0, window.location.href.split("/").indexOf(crumb) + 1)
+        .slice(0, window.location.pathname.split("/").indexOf(crumb) + 1)
         .join("/");
       return {
-        href,
+        href: `${window.location.protocol}//${window.location.host}${path}`,
         key: crumb,
         text:
-          getPathNameFromLink(href.slice(href.indexOf(lang))) ||
+          getPathNameFromLink(path.slice(path.indexOf(lang))) ||
           getHeaderName(
             (crumb[0]?.toUpperCase() + crumb.slice(1)) as OuterHeaders,
           ),

--- a/www/src/components/docs/pageContent.astro
+++ b/www/src/components/docs/pageContent.astro
@@ -22,7 +22,9 @@ const isRtl = getIsRtlFromLangCode((lang || "en") as KnownLanguageCode);
 
 <article id="article" class="flex w-full max-w-screen-lg flex-col">
   {lang && lang !== "en" && <OutdatedDocsBanner path={path} />}
-  <BreadCrumbs client:only />
+  <div class="h-10">
+    <BreadCrumbs client:only />
+  </div>
   <OnThisPageLinks
     client:media="(max-width: 1024px)"
     headings={headings}


### PR DESCRIPTION
Closes #958 
Closes #959

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Breadcrumbs now work when there is a hash in the url (they now use `location.pathname` instead of `location.href`)
- Removed layout shift when they load

---

## Screenshots

![image](https://user-images.githubusercontent.com/35634442/206923804-24e84142-d6e4-434f-a7fb-4af4050854ee.png)

💯
