### PR TITLE
fix(docs): correction of language matching

### DIFF
--- a/www/src/components/navigation/leftSidebar.astro
+++ b/www/src/components/navigation/leftSidebar.astro
@@ -40,8 +40,8 @@ if (langCode !== "en") {
           .flat()
           .find(
             ({ link: nativeLink }) =>
-              // trailing slash + language code = 3 characters
-              nativeLink.slice(3) === item.link.slice(3),
+              // trailing slash + language code
+              nativeLink.slice(langCode.length + 1) === item.link.slice(3),
           );
         return {
           text: match?.text ?? item.text,

--- a/www/src/languages.ts
+++ b/www/src/languages.ts
@@ -1,7 +1,7 @@
 import type { KnownLanguageCode } from "./config";
 export { KNOWN_LANGUAGES, type KnownLanguageCode } from "./config";
 
-export const langPathRegex = /\/([a-z]{2}-?[A-Z]{0,2})\//;
+export const langPathRegex = /\/([a-z]{2}-?[a-zA-Z]{0,2})\//;
 
 export function getLanguageFromURL(pathname: string) {
   const langCodeMatch = pathname.match(langPathRegex);


### PR DESCRIPTION
we should support different versions of languages such as `zh-cn`,`zh-tw`,` pt-br`
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

_[Short description of what has changed]_
- `langPathRegex` should allow lower case letters, like
[astro](https://github.com/withastro/docs/blob/main/src/i18n/languages.ts)
- Corrected the link matching of sidebar, the length of language code can be more than two 
---

## Screenshots

<img width="1393" alt="image" src="https://user-images.githubusercontent.com/20871468/207323409-cf416e73-7aaf-482c-b3ca-95d9fb2e52ef.png">


💯
