### PR TITLE
fix: missing async keyword

### DIFF
--- a/www/src/pages/en/usage/next-auth.md
+++ b/www/src/pages/en/usage/next-auth.md
@@ -118,7 +118,7 @@ The session object is a light, minimal representation of the user and only conta
 
 ```ts:server/trpc/router/user.ts
 const userRouter = router({
-  me: protectedProcedure.query(({ ctx }) => {
+  me: protectedProcedure.query(async ({ ctx }) => {
     const user = await prisma.user.findUnique({
       where: {
         id: ctx.session.user.id,


### PR DESCRIPTION
Use of await inside the `me` protectedProcedure requires the query to be async.

Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯
