### PR TITLE
fix(docs): correction of langCode matching

### DIFF
--- a/www/src/languages.ts
+++ b/www/src/languages.ts
@@ -1,7 +1,7 @@
 import type { KnownLanguageCode } from "./config";
 export { KNOWN_LANGUAGES, type KnownLanguageCode } from "./config";
 
-export const langPathRegex = /\/([a-z]{2}-?[a-zA-Z]{0,2})\//;
+export const langPathRegex = /\/([a-z]{2,3}-?[a-zA-Z]{0,4})\//;
 
 export function getLanguageFromURL(pathname: string) {
   const langCodeMatch = pathname.match(langPathRegex);


### PR DESCRIPTION
make `langPathRegex` can match `zh-hans` and `arc` from rtlLanguages
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯
