### PR TITLE
fix: tailwind base styles are duplicated

### DIFF
--- a/www/astro.config.mjs
+++ b/www/astro.config.mjs
@@ -47,7 +47,7 @@ export default defineConfig({
   },
   integrations: [
     react(),
-    tailwind(),
+    tailwind({ config: { applyBaseStyles: false } }),
     image({
       serviceEntryPoint: "@astrojs/image/sharp",
     }),


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

On the docs site, all tailwind base styles were included twice in the bundled .css files. First are added by the tailwind astro integration, second by `@tailwind base` line in `global.css`.
This PR adds a config to the astro integration to fix that.

---

## Screenshots

![image](https://user-images.githubusercontent.com/35634442/208301558-c123bf9d-e794-4d1c-90f8-cfc527607b76.png)

![image](https://user-images.githubusercontent.com/35634442/208301252-f432cec4-192f-4395-be0e-2cc1fab8a630.png)


💯
