### PR TITLE
docs: Fix active color overflow of the Input with the search icon in t…

### DIFF
--- a/www/src/styles/algolia/style.css
+++ b/www/src/styles/algolia/style.css
@@ -171,6 +171,9 @@ html.dark {
   margin: 0;
   padding: 0;
 }
+.DocSearch-Reset {
+  margin-inline-start: 12px;
+}
 .DocSearch-MagnifierLabel,
 .DocSearch-Reset {
   align-items: center;
@@ -231,6 +234,7 @@ html.dark {
   display: none;
 }
 .DocSearch-Dropdown {
+  margin-top: 10px;
   max-height: calc(
     var(--docsearch-modal-height) - var(--docsearch-searchbox-height) -
       var(--docsearch-spacing) - var(--docsearch-footer-height)

--- a/www/src/styles/algolia/style.css
+++ b/www/src/styles/algolia/style.css
@@ -63,7 +63,7 @@ html.dark {
 }
 .DocSearch-Search-Icon {
   stroke-width: 1.6;
-  margin-right: 15px;
+  margin-inline-end: 15px;
 }
 .DocSearch-Button .DocSearch-Search-Icon {
   color: var(--docsearch-text-color);

--- a/www/src/styles/algolia/style.css
+++ b/www/src/styles/algolia/style.css
@@ -63,6 +63,7 @@ html.dark {
 }
 .DocSearch-Search-Icon {
   stroke-width: 1.6;
+  margin-right: 15px;
 }
 .DocSearch-Button .DocSearch-Search-Icon {
   color: var(--docsearch-text-color);


### PR DESCRIPTION
 Fix active color overflow of the Input with the search icon in the Search component

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

This is really a small fix. The problem was that when the input is active, the active color overflows (clashes) the search icon in the Search modal component. I will provide screenshots illustrating the before and after state of the UI. I couldn't find an open issue for this and I'm not sure If I need to open one before trying to contribute at all. If that's the case, I'll be happy to follow that rule.

---

## Screenshots

Current state: 
![image](https://user-images.githubusercontent.com/42126548/208781342-2a6961a1-c8b4-49f1-938f-7551541b95bb.png)

After the change:
![image](https://user-images.githubusercontent.com/42126548/208781378-cca84917-5db2-48f7-9771-aee88daea005.png)

PNPM check:
![image](https://user-images.githubusercontent.com/42126548/208781434-eac3d359-b2db-4ebb-8d72-32a5d01bb5c9.png)


