### PR TITLE
chore(template): add @types/prettier package to tailwind installer

### DIFF
--- a/.changeset/proud-rabbits-film.md
+++ b/.changeset/proud-rabbits-film.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+chore(create-t3-app): add @types/prettier package to tailwind installer and bump prettier versions

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -35,7 +35,7 @@ export const dependencyVersionMap = {
   postcss: "^8.4.14",
   prettier: "^2.8.1",
   "prettier-plugin-tailwindcss": "^0.2.1",
-  "@types/prettier": "^2.8.1",
+  "@types/prettier": "^2.7.2",
 
   // tRPC
   "@trpc/client": "^10.0.0",

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -33,9 +33,9 @@ export const dependencyVersionMap = {
   tailwindcss: "^3.2.0",
   autoprefixer: "^10.4.7",
   postcss: "^8.4.14",
-  prettier: "^2.7.1",
-  "prettier-plugin-tailwindcss": "^0.1.13",
-  "@types/prettier": "^2.7.1",
+  prettier: "^2.8.1",
+  "prettier-plugin-tailwindcss": "^0.2.1",
+  "@types/prettier": "^2.8.1",
 
   // tRPC
   "@trpc/client": "^10.0.0",

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -35,6 +35,7 @@ export const dependencyVersionMap = {
   postcss: "^8.4.14",
   prettier: "^2.7.1",
   "prettier-plugin-tailwindcss": "^0.1.13",
+  "@types/prettier": "^2.7.1",
 
   // tRPC
   "@trpc/client": "^10.0.0",

--- a/cli/src/installers/tailwind.ts
+++ b/cli/src/installers/tailwind.ts
@@ -13,6 +13,7 @@ export const tailwindInstaller: Installer = ({ projectDir }) => {
       "autoprefixer",
       "prettier",
       "prettier-plugin-tailwindcss",
+      "@types/prettier",
     ],
     devMode: true,
   });


### PR DESCRIPTION
Closes  #1009

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

`@types/prettier` is now added as a dependency to the project when the Tailwind addon is selected, this ensures auto-completion in the Prettier config file in VS Code after a fresh project init.

---

## Screenshots

<img width="1136" alt="截圖 2022-12-26 12 08 36" src="https://user-images.githubusercontent.com/17215508/209543250-c65d767a-77a8-4820-8d19-9bc8b8aa6f9b.png">

💯
