### PR TITLE
chore: remove redundant content in folder structure file

### DIFF
--- a/www/src/pages/en/folder-structure.mdx
+++ b/www/src/pages/en/folder-structure.mdx
@@ -46,7 +46,7 @@ The `pages` folder contains all the pages of the Next.js application. The `index
 
 #### `src/pages/api`
 
-The `api` folder contains all the API routes of the Next.js application. The `examples.ts` file (with Prisma) contains an example of a route that uses the [Next.js API route](https://nextjs.org/docs/api-routes/introduction) feature along with Prisma. The `restricted.ts` file (with Next-Auth) contains an example of a route that uses the [Next.js API route](https://nextjs.org/docs/api-routes/introduction) feature and is protected by [NextAuth.js](https://next-auth.js.org/).
+The `api` folder contains all the API routes of the Next.js application. The `examples.ts` file contains an example of a route that uses the [Next.js API route](https://nextjs.org/docs/api-routes/introduction) feature along with Prisma. The `restricted.ts` file contains an example of a route that uses the [Next.js API route](https://nextjs.org/docs/api-routes/introduction) feature and is protected by [NextAuth.js](https://next-auth.js.org/).
 
 </div>
 <div data-components="nextauth">


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

I think the content inside the parentheses were added, to give an indication of what to expect when selecting the `--prisma`, and `--nextAuth` flags. Because of the existences of the selector, these two can go.

![image](https://user-images.githubusercontent.com/88248797/209547131-d07bf1e8-dcbe-4781-a856-6889c0bd91a0.png)


---

## Screenshots

_[Screenshots]_

💯
