### PR TITLE
refactor(docs): split config out per language

### DIFF
--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -1,3 +1,14 @@
+import { SIDEBAR_AR, SIDEBAR_HEADER_MAP_AR } from "./pages/ar/_config/configAr";
+import { SIDEBAR_EN } from "./pages/en/_config/configEn";
+import { SIDEBAR_FR, SIDEBAR_HEADER_MAP_FR } from "./pages/fr/_config/configFr";
+import { SIDEBAR_HEADER_MAP_NO, SIDEBAR_NO } from "./pages/no/_config/configNo";
+import { SIDEBAR_HEADER_MAP_PT, SIDEBAR_PT } from "./pages/pt/_config/configPt";
+import { SIDEBAR_HEADER_MAP_RU, SIDEBAR_RU } from "./pages/ru/_config/configRu";
+import {
+  SIDEBAR_HEADER_MAP_ZH_HANS,
+  SIDEBAR_ZH_HANS,
+} from "./pages/zh-hans/_config/configZhHans";
+
 export const SITE = {
   title: "Create T3 App",
   description: "The best way to start a full-stack, typesafe Next.js app.",
@@ -63,252 +74,36 @@ export const SIDEBAR: Sidebar = {
   // Translate the "inner headers" to the language you're translating to.
   // Omit any files you haven't translated, they'll fallback to English.
   // Example:
-  // sv: {
+  // SIDEBAR_SV: {
   //   "Create T3 App": [
   //     { text: "Introduktion", link: "sv/introduction" },
   //     { text: "Installation", link: "sv/installation" },
   //   ],
   //   Usage: [{ text: "Miljövariabler", link: "sv/usage/env-variables" }],
   // },
-  ar: {
-    "Create T3 App": [
-      { text: "مُقدمة", link: "ar/introduction" },
-      { text: "لماذا CT3A؟", link: "ar/why" },
-      { text: "التثبيت", link: "ar/installation" },
-      { text: "بِنية المجلد", link: "ar/folder-structure" },
-      { text: "أسئلة شائعة", link: "ar/faq" },
-      { text: "تطبيقات صُنعت بواسطة T3", link: "ar/t3-collection" },
-      { text: "ترشيحات أُخري", link: "ar/other-recs" },
-    ],
-    Usage: [
-      { text: "الخُطوات الأُولي", link: "ar/usage/first-steps" },
-      { text: "Next.js", link: "ar/usage/next-js" },
-      { text: "TypeScript", link: "ar/usage/typescript" },
-      { text: "tRPC", link: "ar/usage/trpc" },
-      { text: "Prisma", link: "ar/usage/prisma" },
-      { text: "NextAuth.js", link: "ar/usage/next-auth" },
-      {
-        text: "Environment Variables",
-        link: "ar/usage/env-variables",
-      },
-      { text: "Tailwind CSS", link: "ar/usage/tailwind" },
-    ],
-    Deployment: [
-      { text: "Vercel", link: "ar/deployment/vercel" },
-      { text: "Docker", link: "ar/deployment/docker" },
-    ],
-  },
-  en: {
-    "Create T3 App": [
-      { text: "Introduction", link: "en/introduction" },
-      { text: "Why CT3A?", link: "en/why" },
-      { text: "Installation", link: "en/installation" },
-      { text: "Folder Structure", link: "en/folder-structure" },
-      { text: "FAQ", link: "en/faq" },
-      { text: "T3 Collection", link: "en/t3-collection" },
-      { text: "Other Recommendations", link: "en/other-recs" },
-    ],
-    Usage: [
-      { text: "First Steps", link: "en/usage/first-steps" },
-      { text: "Next.js", link: "en/usage/next-js" },
-      { text: "TypeScript", link: "en/usage/typescript" },
-      { text: "tRPC", link: "en/usage/trpc" },
-      { text: "Prisma", link: "en/usage/prisma" },
-      { text: "NextAuth.js", link: "en/usage/next-auth" },
-      {
-        text: "Environment Variables",
-        link: "en/usage/env-variables",
-      },
-      { text: "Tailwind CSS", link: "en/usage/tailwind" },
-    ],
-    Deployment: [
-      { text: "Vercel", link: "en/deployment/vercel" },
-      { text: "Netlify", link: "en/deployment/netlify" },
-      { text: "Docker", link: "en/deployment/docker" },
-    ],
-  },
-  fr: {
-    "Create T3 App": [
-      { text: "Introduction", link: "fr/introduction" },
-      { text: "Pourquoi CT3A?", link: "fr/why" },
-      { text: "Installation", link: "fr/installation" },
-      { text: "Structure des dossiers", link: "fr/folder-structure" },
-      { text: "FAQ", link: "fr/faq" },
-      { text: "Collection T3", link: "fr/t3-collection" },
-      { text: "Autres recommandations", link: "fr/other-recs" },
-    ],
-    Usage: [
-      { text: "Premiers pas", link: "fr/usage/first-steps" },
-      { text: "Next.js", link: "fr/usage/next-js" },
-      { text: "TypeScript", link: "fr/usage/typescript" },
-      { text: "tRPC", link: "fr/usage/trpc" },
-      { text: "Prisma", link: "fr/usage/prisma" },
-      { text: "NextAuth.js", link: "fr/usage/next-auth" },
-      {
-        text: "Variables d'environnement",
-        link: "fr/usage/env-variables",
-      },
-      { text: "Tailwind CSS", link: "fr/usage/tailwind" },
-    ],
-    Deployment: [
-      { text: "Vercel", link: "fr/deployment/vercel" },
-      { text: "Netlify", link: "fr/deployment/netlify" },
-      { text: "Docker", link: "fr/deployment/docker" },
-    ],
-  },
-  pt: {
-    "Create T3 App": [
-      { text: "Introdução", link: "pt/introduction" },
-      { text: "Por que o CT3A?", link: "pt/why" },
-      { text: "Instalação", link: "pt/installation" },
-      { text: "Estrutura de Pastas", link: "pt/folder-structure" },
-      { text: "Perguntas Frequentes", link: "pt/faq" },
-      { text: "Coleção T3", link: "pt/t3-collection" },
-      { text: "Outras Recomendações", link: "pt/other-recs" },
-    ],
-    Usage: [
-      { text: "Primeiros Passos", link: "pt/usage/first-steps" },
-      { text: "Next.js", link: "pt/usage/next-js" },
-      { text: "TypeScript", link: "pt/usage/typescript" },
-      { text: "tRPC", link: "pt/usage/trpc" },
-      { text: "Prisma", link: "pt/usage/prisma" },
-      { text: "NextAuth.js", link: "pt/usage/next-auth" },
-      {
-        text: "Variáveis de Ambiente",
-        link: "pt/usage/env-variables",
-      },
-      { text: "Tailwind CSS", link: "pt/usage/tailwind" },
-    ],
-    Deployment: [
-      { text: "Vercel", link: "pt/deployment/vercel" },
-      { text: "Docker", link: "pt/deployment/docker" },
-    ],
-  },
-  ru: {
-    "Create T3 App": [
-      { text: "Введение", link: "ru/introduction" },
-      { text: "Почему CT3A?", link: "ru/why" },
-      { text: "Установка", link: "ru/installation" },
-      { text: "Файловая структура", link: "ru/folder-structure" },
-      { text: "FAQ", link: "ru/faq" },
-      { text: "T3 коллекция", link: "ru/t3-collection" },
-      { text: "Дополнительные рекомендации", link: "ru/other-recs" },
-    ],
-    Usage: [
-      { text: "Первые шаги", link: "ru/usage/first-steps" },
-      { text: "Next.js", link: "ru/usage/next-js" },
-      { text: "TypeScript", link: "ru/usage/typescript" },
-      { text: "tRPC", link: "ru/usage/trpc" },
-      { text: "Prisma", link: "ru/usage/prisma" },
-      { text: "NextAuth.js", link: "ru/usage/next-auth" },
-      {
-        text: "Переменные среды",
-        link: "ru/usage/env-variables",
-      },
-      { text: "Tailwind CSS", link: "ru/usage/tailwind" },
-    ],
-    Deployment: [
-      { text: "Vercel", link: "ru/deployment/vercel" },
-      { text: "Docker", link: "ru/deployment/docker" },
-    ],
-  },
-  no: {
-    "Create T3 App": [
-      { text: "Introduksjon", link: "no/introduction" },
-      { text: "Hvorfor CT3A?", link: "no/why" },
-      { text: "Installasjon", link: "no/installation" },
-      { text: "Mappestruktur", link: "no/folder-structure" },
-      { text: "FAQ", link: "no/faq" },
-      { text: "T3-Kolleksjonen", link: "no/t3-collection" },
-      { text: "Andre Anbefalinger", link: "no/other-recs" },
-    ],
-    Usage: [
-      { text: "Første Steg", link: "no/usage/first-steps" },
-      { text: "Next.js", link: "no/usage/next-js" },
-      { text: "TypeScript", link: "no/usage/typescript" },
-      { text: "tRPC", link: "no/usage/trpc" },
-      { text: "Prisma", link: "no/usage/prisma" },
-      { text: "NextAuth.js", link: "no/usage/next-auth" },
-      {
-        text: "Miljøvariabler",
-        link: "no/usage/env-variables",
-      },
-      { text: "Tailwind CSS", link: "no/usage/tailwind" },
-    ],
-    Deployment: [
-      { text: "Vercel", link: "no/deployment/vercel" },
-      { text: "Docker", link: "no/deployment/docker" },
-    ],
-  },
-  "zh-hans": {
-    "Create T3 App": [
-      { text: "简介", link: "zh-hans/introduction" },
-      { text: "为什么选择 CT3A?", link: "zh-hans/why" },
-      { text: "安装", link: "zh-hans/installation" },
-      { text: "文件夹结构", link: "zh-hans/folder-structure" },
-      { text: "常见疑问", link: "zh-hans/faq" },
-      { text: "T3 合集", link: "zh-hans/t3-collection" },
-      { text: "其他推荐", link: "zh-hans/other-recs" },
-    ],
-    Usage: [
-      { text: "第一步", link: "zh-hans/usage/first-steps" },
-      { text: "Next.js", link: "zh-hans/usage/next-js" },
-      { text: "TypeScript", link: "zh-hans/usage/typescript" },
-      { text: "tRPC", link: "zh-hans/usage/trpc" },
-      { text: "Prisma", link: "zh-hans/usage/prisma" },
-      { text: "NextAuth.js", link: "zh-hans/usage/next-auth" },
-      {
-        text: "环境变量",
-        link: "zh-hans/usage/env-variables",
-      },
-      { text: "Tailwind CSS", link: "zh-hans/usage/tailwind" },
-    ],
-    Deployment: [
-      { text: "Vercel", link: "zh-hans/deployment/vercel" },
-      { text: "Netlify", link: "zh-hans/deployment/netlify" },
-      { text: "Docker", link: "zh-hans/deployment/docker" },
-    ],
-  },
+  ar: SIDEBAR_AR,
+  en: SIDEBAR_EN,
+  fr: SIDEBAR_FR,
+  no: SIDEBAR_NO,
+  pt: SIDEBAR_PT,
+  ru: SIDEBAR_RU,
+  "zh-hans": SIDEBAR_ZH_HANS,
 };
 
 export const SIDEBAR_HEADER_MAP: Record<
   Exclude<KnownLanguageCode, "en">,
   Record<OuterHeaders, string>
 > = {
-  // Translate the sidebar's "outer headers" here
-  // sv: {
+  // Translate the sidebar's "outer headers"
+  // SIDEBAR_HEADER_MAP_SV: {
   //   "Create T3 App": "Create T3 App",
   //   Usage: "Användarguide",
   //   Deployment: "Deployment",
   // },
-  ar: {
-    "Create T3 App": "Create T3 App",
-    Usage: "كيفية الإستخدام؟",
-    Deployment: "نَشر تطبيقك",
-  },
-  fr: {
-    "Create T3 App": "Create T3 App",
-    Usage: "Utilisation",
-    Deployment: "Déploiement",
-  },
-  pt: {
-    "Create T3 App": "Create T3 App",
-    Usage: "Uso",
-    Deployment: "Deploy",
-  },
-  ru: {
-    "Create T3 App": "Create T3 App",
-    Usage: "Использование",
-    Deployment: "Развертывание",
-  },
-  no: {
-    "Create T3 App": "Create T3 App",
-    Usage: "Bruk",
-    Deployment: "Utrulling",
-  },
-  "zh-hans": {
-    "Create T3 App": "Create T3 App",
-    Usage: "用法",
-    Deployment: "部署",
-  },
+  ar: SIDEBAR_HEADER_MAP_AR,
+  fr: SIDEBAR_HEADER_MAP_FR,
+  no: SIDEBAR_HEADER_MAP_NO,
+  pt: SIDEBAR_HEADER_MAP_PT,
+  ru: SIDEBAR_HEADER_MAP_RU,
+  "zh-hans": SIDEBAR_HEADER_MAP_ZH_HANS,
 };

--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -74,7 +74,7 @@ export const SIDEBAR: Sidebar = {
   // Translate the "inner headers" to the language you're translating to.
   // Omit any files you haven't translated, they'll fallback to English.
   // Example:
-  // SIDEBAR_SV: {
+  // export const SIDEBAR_SV: Sidebar["sv"] = {
   //   "Create T3 App": [
   //     { text: "Introduktion", link: "sv/introduction" },
   //     { text: "Installation", link: "sv/installation" },

--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -90,12 +90,13 @@ export const SIDEBAR: Sidebar = {
   "zh-hans": SIDEBAR_ZH_HANS,
 };
 
+export type SidebarHeaders = Record<OuterHeaders, string>;
 export const SIDEBAR_HEADER_MAP: Record<
   Exclude<KnownLanguageCode, "en">,
-  Record<OuterHeaders, string>
+  SidebarHeaders
 > = {
   // Translate the sidebar's "outer headers"
-  // SIDEBAR_HEADER_MAP_SV: {
+  // export const SIDEBAR_HEADER_MAP_SV: SidebarHeaders = {
   //   "Create T3 App": "Create T3 App",
   //   Usage: "Användarguide",
   //   Deployment: "Deployment",

--- a/www/src/pages/ar/_config/configAr.ts
+++ b/www/src/pages/ar/_config/configAr.ts
@@ -1,4 +1,4 @@
-import type { OuterHeaders, Sidebar } from "../../../config";
+import type { Sidebar, SidebarHeaders } from "../../../config";
 
 export const SIDEBAR_AR: Sidebar["ar"] = {
   "Create T3 App": [
@@ -29,7 +29,7 @@ export const SIDEBAR_AR: Sidebar["ar"] = {
   ],
 };
 
-export const SIDEBAR_HEADER_MAP_AR: Record<OuterHeaders, string> = {
+export const SIDEBAR_HEADER_MAP_AR: SidebarHeaders = {
   "Create T3 App": "Create T3 App",
   Usage: "كيفية الإستخدام؟",
   Deployment: "نَشر تطبيقك",

--- a/www/src/pages/ar/_config/configAr.ts
+++ b/www/src/pages/ar/_config/configAr.ts
@@ -1,0 +1,36 @@
+import type { OuterHeaders, Sidebar } from "../../../config";
+
+export const SIDEBAR_AR: Sidebar["ar"] = {
+  "Create T3 App": [
+    { text: "مُقدمة", link: "ar/introduction" },
+    { text: "لماذا CT3A؟", link: "ar/why" },
+    { text: "التثبيت", link: "ar/installation" },
+    { text: "بِنية المجلد", link: "ar/folder-structure" },
+    { text: "أسئلة شائعة", link: "ar/faq" },
+    { text: "تطبيقات صُنعت بواسطة T3", link: "ar/t3-collection" },
+    { text: "ترشيحات أُخري", link: "ar/other-recs" },
+  ],
+  Usage: [
+    { text: "الخُطوات الأُولي", link: "ar/usage/first-steps" },
+    { text: "Next.js", link: "ar/usage/next-js" },
+    { text: "TypeScript", link: "ar/usage/typescript" },
+    { text: "tRPC", link: "ar/usage/trpc" },
+    { text: "Prisma", link: "ar/usage/prisma" },
+    { text: "NextAuth.js", link: "ar/usage/next-auth" },
+    {
+      text: "Environment Variables",
+      link: "ar/usage/env-variables",
+    },
+    { text: "Tailwind CSS", link: "ar/usage/tailwind" },
+  ],
+  Deployment: [
+    { text: "Vercel", link: "ar/deployment/vercel" },
+    { text: "Docker", link: "ar/deployment/docker" },
+  ],
+};
+
+export const SIDEBAR_HEADER_MAP_AR: Record<OuterHeaders, string> = {
+  "Create T3 App": "Create T3 App",
+  Usage: "كيفية الإستخدام؟",
+  Deployment: "نَشر تطبيقك",
+};

--- a/www/src/pages/en/_config/configEn.ts
+++ b/www/src/pages/en/_config/configEn.ts
@@ -1,0 +1,31 @@
+import type { Sidebar } from "../../../config";
+
+export const SIDEBAR_EN: Sidebar["en"] = {
+  "Create T3 App": [
+    { text: "Introduction", link: "en/introduction" },
+    { text: "Why CT3A?", link: "en/why" },
+    { text: "Installation", link: "en/installation" },
+    { text: "Folder Structure", link: "en/folder-structure" },
+    { text: "FAQ", link: "en/faq" },
+    { text: "T3 Collection", link: "en/t3-collection" },
+    { text: "Other Recommendations", link: "en/other-recs" },
+  ],
+  Usage: [
+    { text: "First Steps", link: "en/usage/first-steps" },
+    { text: "Next.js", link: "en/usage/next-js" },
+    { text: "TypeScript", link: "en/usage/typescript" },
+    { text: "tRPC", link: "en/usage/trpc" },
+    { text: "Prisma", link: "en/usage/prisma" },
+    { text: "NextAuth.js", link: "en/usage/next-auth" },
+    {
+      text: "Environment Variables",
+      link: "en/usage/env-variables",
+    },
+    { text: "Tailwind CSS", link: "en/usage/tailwind" },
+  ],
+  Deployment: [
+    { text: "Vercel", link: "en/deployment/vercel" },
+    { text: "Netlify", link: "en/deployment/netlify" },
+    { text: "Docker", link: "en/deployment/docker" },
+  ],
+};

--- a/www/src/pages/fr/_config/configFr.ts
+++ b/www/src/pages/fr/_config/configFr.ts
@@ -1,4 +1,4 @@
-import type { OuterHeaders, Sidebar } from "../../../config";
+import type { Sidebar, SidebarHeaders } from "../../../config";
 
 export const SIDEBAR_FR: Sidebar["fr"] = {
   "Create T3 App": [
@@ -30,7 +30,7 @@ export const SIDEBAR_FR: Sidebar["fr"] = {
   ],
 };
 
-export const SIDEBAR_HEADER_MAP_FR: Record<OuterHeaders, string> = {
+export const SIDEBAR_HEADER_MAP_FR: SidebarHeaders = {
   "Create T3 App": "Create T3 App",
   Usage: "Utilisation",
   Deployment: "Déploiement",

--- a/www/src/pages/fr/_config/configFr.ts
+++ b/www/src/pages/fr/_config/configFr.ts
@@ -1,0 +1,37 @@
+import type { OuterHeaders, Sidebar } from "../../../config";
+
+export const SIDEBAR_FR: Sidebar["fr"] = {
+  "Create T3 App": [
+    { text: "Introduction", link: "fr/introduction" },
+    { text: "Pourquoi CT3A?", link: "fr/why" },
+    { text: "Installation", link: "fr/installation" },
+    { text: "Structure des dossiers", link: "fr/folder-structure" },
+    { text: "FAQ", link: "fr/faq" },
+    { text: "Collection T3", link: "fr/t3-collection" },
+    { text: "Autres recommandations", link: "fr/other-recs" },
+  ],
+  Usage: [
+    { text: "Premiers pas", link: "fr/usage/first-steps" },
+    { text: "Next.js", link: "fr/usage/next-js" },
+    { text: "TypeScript", link: "fr/usage/typescript" },
+    { text: "tRPC", link: "fr/usage/trpc" },
+    { text: "Prisma", link: "fr/usage/prisma" },
+    { text: "NextAuth.js", link: "fr/usage/next-auth" },
+    {
+      text: "Variables d'environnement",
+      link: "fr/usage/env-variables",
+    },
+    { text: "Tailwind CSS", link: "fr/usage/tailwind" },
+  ],
+  Deployment: [
+    { text: "Vercel", link: "fr/deployment/vercel" },
+    { text: "Netlify", link: "fr/deployment/netlify" },
+    { text: "Docker", link: "fr/deployment/docker" },
+  ],
+};
+
+export const SIDEBAR_HEADER_MAP_FR: Record<OuterHeaders, string> = {
+  "Create T3 App": "Create T3 App",
+  Usage: "Utilisation",
+  Deployment: "Déploiement",
+};

--- a/www/src/pages/no/_config/configNo.ts
+++ b/www/src/pages/no/_config/configNo.ts
@@ -1,4 +1,4 @@
-import type { OuterHeaders, Sidebar } from "../../../config";
+import type { Sidebar, SidebarHeaders } from "../../../config";
 
 export const SIDEBAR_NO: Sidebar["no"] = {
   "Create T3 App": [
@@ -29,7 +29,7 @@ export const SIDEBAR_NO: Sidebar["no"] = {
   ],
 };
 
-export const SIDEBAR_HEADER_MAP_NO: Record<OuterHeaders, string> = {
+export const SIDEBAR_HEADER_MAP_NO: SidebarHeaders = {
   "Create T3 App": "Create T3 App",
   Usage: "Bruk",
   Deployment: "Utrulling",

--- a/www/src/pages/no/_config/configNo.ts
+++ b/www/src/pages/no/_config/configNo.ts
@@ -1,0 +1,36 @@
+import type { OuterHeaders, Sidebar } from "../../../config";
+
+export const SIDEBAR_NO: Sidebar["no"] = {
+  "Create T3 App": [
+    { text: "Introduksjon", link: "no/introduction" },
+    { text: "Hvorfor CT3A?", link: "no/why" },
+    { text: "Installasjon", link: "no/installation" },
+    { text: "Mappestruktur", link: "no/folder-structure" },
+    { text: "FAQ", link: "no/faq" },
+    { text: "T3-Kolleksjonen", link: "no/t3-collection" },
+    { text: "Andre Anbefalinger", link: "no/other-recs" },
+  ],
+  Usage: [
+    { text: "Første Steg", link: "no/usage/first-steps" },
+    { text: "Next.js", link: "no/usage/next-js" },
+    { text: "TypeScript", link: "no/usage/typescript" },
+    { text: "tRPC", link: "no/usage/trpc" },
+    { text: "Prisma", link: "no/usage/prisma" },
+    { text: "NextAuth.js", link: "no/usage/next-auth" },
+    {
+      text: "Miljøvariabler",
+      link: "no/usage/env-variables",
+    },
+    { text: "Tailwind CSS", link: "no/usage/tailwind" },
+  ],
+  Deployment: [
+    { text: "Vercel", link: "no/deployment/vercel" },
+    { text: "Docker", link: "no/deployment/docker" },
+  ],
+};
+
+export const SIDEBAR_HEADER_MAP_NO: Record<OuterHeaders, string> = {
+  "Create T3 App": "Create T3 App",
+  Usage: "Bruk",
+  Deployment: "Utrulling",
+};

--- a/www/src/pages/pt/_config/configPt.ts
+++ b/www/src/pages/pt/_config/configPt.ts
@@ -1,4 +1,4 @@
-import type { OuterHeaders, Sidebar } from "../../../config";
+import type { Sidebar, SidebarHeaders } from "../../../config";
 
 export const SIDEBAR_PT: Sidebar["pt"] = {
   "Create T3 App": [
@@ -29,7 +29,7 @@ export const SIDEBAR_PT: Sidebar["pt"] = {
   ],
 };
 
-export const SIDEBAR_HEADER_MAP_PT: Record<OuterHeaders, string> = {
+export const SIDEBAR_HEADER_MAP_PT: SidebarHeaders = {
   "Create T3 App": "Create T3 App",
   Usage: "Uso",
   Deployment: "Deploy",

--- a/www/src/pages/pt/_config/configPt.ts
+++ b/www/src/pages/pt/_config/configPt.ts
@@ -1,0 +1,36 @@
+import type { OuterHeaders, Sidebar } from "../../../config";
+
+export const SIDEBAR_PT: Sidebar["pt"] = {
+  "Create T3 App": [
+    { text: "Introdução", link: "pt/introduction" },
+    { text: "Por que o CT3A?", link: "pt/why" },
+    { text: "Instalação", link: "pt/installation" },
+    { text: "Estrutura de Pastas", link: "pt/folder-structure" },
+    { text: "Perguntas Frequentes", link: "pt/faq" },
+    { text: "Coleção T3", link: "pt/t3-collection" },
+    { text: "Outras Recomendações", link: "pt/other-recs" },
+  ],
+  Usage: [
+    { text: "Primeiros Passos", link: "pt/usage/first-steps" },
+    { text: "Next.js", link: "pt/usage/next-js" },
+    { text: "TypeScript", link: "pt/usage/typescript" },
+    { text: "tRPC", link: "pt/usage/trpc" },
+    { text: "Prisma", link: "pt/usage/prisma" },
+    { text: "NextAuth.js", link: "pt/usage/next-auth" },
+    {
+      text: "Variáveis de Ambiente",
+      link: "pt/usage/env-variables",
+    },
+    { text: "Tailwind CSS", link: "pt/usage/tailwind" },
+  ],
+  Deployment: [
+    { text: "Vercel", link: "pt/deployment/vercel" },
+    { text: "Docker", link: "pt/deployment/docker" },
+  ],
+};
+
+export const SIDEBAR_HEADER_MAP_PT: Record<OuterHeaders, string> = {
+  "Create T3 App": "Create T3 App",
+  Usage: "Uso",
+  Deployment: "Deploy",
+};

--- a/www/src/pages/ru/_config/configRu.ts
+++ b/www/src/pages/ru/_config/configRu.ts
@@ -1,4 +1,4 @@
-import type { OuterHeaders, Sidebar } from "../../../config";
+import type { Sidebar, SidebarHeaders } from "../../../config";
 
 export const SIDEBAR_RU: Sidebar["ru"] = {
   "Create T3 App": [
@@ -29,7 +29,7 @@ export const SIDEBAR_RU: Sidebar["ru"] = {
   ],
 };
 
-export const SIDEBAR_HEADER_MAP_RU: Record<OuterHeaders, string> = {
+export const SIDEBAR_HEADER_MAP_RU: SidebarHeaders = {
   "Create T3 App": "Create T3 App",
   Usage: "Использование",
   Deployment: "Развертывание",

--- a/www/src/pages/ru/_config/configRu.ts
+++ b/www/src/pages/ru/_config/configRu.ts
@@ -1,0 +1,36 @@
+import type { OuterHeaders, Sidebar } from "../../../config";
+
+export const SIDEBAR_RU: Sidebar["ru"] = {
+  "Create T3 App": [
+    { text: "Введение", link: "ru/introduction" },
+    { text: "Почему CT3A?", link: "ru/why" },
+    { text: "Установка", link: "ru/installation" },
+    { text: "Файловая структура", link: "ru/folder-structure" },
+    { text: "FAQ", link: "ru/faq" },
+    { text: "T3 коллекция", link: "ru/t3-collection" },
+    { text: "Дополнительные рекомендации", link: "ru/other-recs" },
+  ],
+  Usage: [
+    { text: "Первые шаги", link: "ru/usage/first-steps" },
+    { text: "Next.js", link: "ru/usage/next-js" },
+    { text: "TypeScript", link: "ru/usage/typescript" },
+    { text: "tRPC", link: "ru/usage/trpc" },
+    { text: "Prisma", link: "ru/usage/prisma" },
+    { text: "NextAuth.js", link: "ru/usage/next-auth" },
+    {
+      text: "Переменные среды",
+      link: "ru/usage/env-variables",
+    },
+    { text: "Tailwind CSS", link: "ru/usage/tailwind" },
+  ],
+  Deployment: [
+    { text: "Vercel", link: "ru/deployment/vercel" },
+    { text: "Docker", link: "ru/deployment/docker" },
+  ],
+};
+
+export const SIDEBAR_HEADER_MAP_RU: Record<OuterHeaders, string> = {
+  "Create T3 App": "Create T3 App",
+  Usage: "Использование",
+  Deployment: "Развертывание",
+};

--- a/www/src/pages/zh-hans/_config/configZhHans.ts
+++ b/www/src/pages/zh-hans/_config/configZhHans.ts
@@ -1,0 +1,37 @@
+import type { OuterHeaders, Sidebar } from "../../../config";
+
+export const SIDEBAR_ZH_HANS: Sidebar["zh-hans"] = {
+  "Create T3 App": [
+    { text: "简介", link: "zh-hans/introduction" },
+    { text: "为什么选择 CT3A?", link: "zh-hans/why" },
+    { text: "安装", link: "zh-hans/installation" },
+    { text: "文件夹结构", link: "zh-hans/folder-structure" },
+    { text: "常见疑问", link: "zh-hans/faq" },
+    { text: "T3 合集", link: "zh-hans/t3-collection" },
+    { text: "其他推荐", link: "zh-hans/other-recs" },
+  ],
+  Usage: [
+    { text: "第一步", link: "zh-hans/usage/first-steps" },
+    { text: "Next.js", link: "zh-hans/usage/next-js" },
+    { text: "TypeScript", link: "zh-hans/usage/typescript" },
+    { text: "tRPC", link: "zh-hans/usage/trpc" },
+    { text: "Prisma", link: "zh-hans/usage/prisma" },
+    { text: "NextAuth.js", link: "zh-hans/usage/next-auth" },
+    {
+      text: "环境变量",
+      link: "zh-hans/usage/env-variables",
+    },
+    { text: "Tailwind CSS", link: "zh-hans/usage/tailwind" },
+  ],
+  Deployment: [
+    { text: "Vercel", link: "zh-hans/deployment/vercel" },
+    { text: "Netlify", link: "zh-hans/deployment/netlify" },
+    { text: "Docker", link: "zh-hans/deployment/docker" },
+  ],
+};
+
+export const SIDEBAR_HEADER_MAP_ZH_HANS: Record<OuterHeaders, string> = {
+  "Create T3 App": "Create T3 App",
+  Usage: "用法",
+  Deployment: "部署",
+};

--- a/www/src/pages/zh-hans/_config/configZhHans.ts
+++ b/www/src/pages/zh-hans/_config/configZhHans.ts
@@ -1,4 +1,4 @@
-import type { OuterHeaders, Sidebar } from "../../../config";
+import type { Sidebar, SidebarHeaders } from "../../../config";
 
 export const SIDEBAR_ZH_HANS: Sidebar["zh-hans"] = {
   "Create T3 App": [
@@ -30,7 +30,7 @@ export const SIDEBAR_ZH_HANS: Sidebar["zh-hans"] = {
   ],
 };
 
-export const SIDEBAR_HEADER_MAP_ZH_HANS: Record<OuterHeaders, string> = {
+export const SIDEBAR_HEADER_MAP_ZH_HANS: SidebarHeaders = {
   "Create T3 App": "Create T3 App",
   Usage: "用法",
   Deployment: "部署",


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- split `config.ts` into per-language files that are inside `pages/<lang>/_config/config<lang>.ts`

The purpose of this is to have them within the folder that the code owners of each language get. I'm open to a different file/naming structure etc but will need to be in `pages/<lang>` to work

💯
