### PR TITLE
fix: revert link icon in RTL layout

### DIFF
--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -180,6 +180,10 @@
           dark:decoration-t3-purple-200 dark:hover:text-t3-purple-300;
   }
 
+  :is([dir='rtl']) .markdown a[rel~="noreferrer"] > span {
+    @apply -scale-x-100 inline-flex;
+}
+
   .markdown code {
     @apply break-words [direction:ltr] [unicode-bidi:embed] lg:break-normal;
   }


### PR DESCRIPTION
Co-authored-by: Julius Marminge <julius0216@outlook.com>

Closes #<1014>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Revert the icon in RTL layout
- Used the `[dir='rtl']` attribute, and used selector to hide it in the devtools.

---

## Screenshots

![image](https://user-images.githubusercontent.com/88248797/209568072-46db5c43-660f-4982-8215-de1af4742513.png)

💯
