### PR TITLE
chore(ci): use pnpm for beta-release comment

### DIFF
--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -48,7 +48,7 @@ jobs:
             A new create-t3-app prerelease is available for testing. You can install this latest build in your project with:
 
             ```sh
-            npx create-t3-app@${{ env.BETA_PACKAGE_VERSION }}
+            pnpm create t3-app@${{ env.BETA_PACKAGE_VERSION }}
             ```
 
       - name: "Remove the autorelease label once published"


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

I think most of us (us as in us who test the beta) use `pnpm` nowadays so makes sense to use it for the beta comment. Too lazy to edit it every time and I want to use my pnpm cache when downloading packages :)

---

## Screenshots

_[Screenshots]_

💯
