### PR TITLE
fix(cli): exit with error code when aborting installation

### DIFF
--- a/.changeset/green-laws-hammer.md
+++ b/.changeset/green-laws-hammer.md
@@ -1,0 +1,6 @@
+---
+"create-t3-app": patch
+---
+
+fix(cli): exit with error code when aborting installation
+fix(cli): don't log when scaffolding in current directory and it's empty

--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -25,10 +25,13 @@ export const scaffoldProject = async ({
   const spinner = ora(`Scaffolding in: ${projectDir}...\n`).start();
 
   if (fs.existsSync(projectDir)) {
-    if (fs.readdirSync(projectDir).length === 0 && projectName !== ".") {
-      spinner.info(
-        `${chalk.cyan.bold(projectName)} exists but is empty, continuing...\n`,
-      );
+    if (fs.readdirSync(projectDir).length === 0) {
+      if (projectName !== ".")
+        spinner.info(
+          `${chalk.cyan.bold(
+            projectName,
+          )} exists but is empty, continuing...\n`,
+        );
     } else {
       spinner.stopAndPersist();
       const { overwriteDir } = await inquirer.prompt<{

--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -25,7 +25,7 @@ export const scaffoldProject = async ({
   const spinner = ora(`Scaffolding in: ${projectDir}...\n`).start();
 
   if (fs.existsSync(projectDir)) {
-    if (fs.readdirSync(projectDir).length === 0) {
+    if (fs.readdirSync(projectDir).length === 0 && projectName !== ".") {
       spinner.info(
         `${chalk.cyan.bold(projectName)} exists but is empty, continuing...\n`,
       );
@@ -60,7 +60,7 @@ export const scaffoldProject = async ({
       });
       if (overwriteDir === "abort") {
         spinner.fail("Aborting installation...");
-        process.exit(0);
+        process.exit(1);
       }
 
       const overwriteAction =
@@ -79,7 +79,7 @@ export const scaffoldProject = async ({
 
       if (!confirmOverwriteDir) {
         spinner.fail("Aborting installation...");
-        process.exit(0);
+        process.exit(1);
       }
 
       if (overwriteDir === "clear") {


### PR DESCRIPTION
Closes #1033
Closes #1029

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Exits with error code if aborted
  
  <img width="659" alt="CleanShot 2023-01-03 at 10 16 33@2x" src="https://user-images.githubusercontent.com/51714798/210328821-d863e936-5c9f-494a-a559-010c125374f0.png">

- Removed log `<dirname> exists but is empty, continuing...` if scaffolded in current directory.
  
  <img width="449" alt="CleanShot 2023-01-03 at 10 14 11@2x" src="https://user-images.githubusercontent.com/51714798/210328466-10a523d4-0acc-47aa-a33c-5efeab144bcc.png">


---

## Screenshots

_[Screenshots]_

💯
