### PR TITLE
feat: add comment about other providers to next-auth API handler (v7)

### DIFF
--- a/cli/template/extras/src/pages/api/auth/[...nextauth]/base.ts
+++ b/cli/template/extras/src/pages/api/auth/[...nextauth]/base.ts
@@ -19,7 +19,15 @@ export const authOptions: NextAuthOptions = {
       clientId: env.DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
     }),
-    // ...add more providers here
+    /**
+     * ...add more providers here
+     *
+     * Most other providers require a bit more work than the Discord provider.
+     * For example, the GitHub provider requires you to add the
+     * `refresh_token_expires_in` field to the Account model. Refer to the
+     * NextAuth.js docs for the provider you want to use. Example:
+     * @see https://next-auth.js.org/providers/github
+     */
   ],
 };
 

--- a/cli/template/extras/src/pages/api/auth/[...nextauth]/with-prisma.ts
+++ b/cli/template/extras/src/pages/api/auth/[...nextauth]/with-prisma.ts
@@ -23,7 +23,15 @@ export const authOptions: NextAuthOptions = {
       clientId: env.DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
     }),
-    // ...add more providers here
+    /**
+     * ...add more providers here
+     *
+     * Most other providers require a bit more work than the Discord provider.
+     * For example, the GitHub provider requires you to add the
+     * `refresh_token_expires_in` field to the Account model. Refer to the
+     * NextAuth.js docs for the provider you want to use. Example:
+     * @see https://next-auth.js.org/providers/github
+     */
   ],
 };
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Easier to close the other branch than trying to resolve v7 merge conflicts in there

We frequently get questions on Discord and other places from people who swap the Discord provider for GitHub or some other one, and then don't understand why their auth is broken. Adding a comment to tell them that they need to look up how each provider works.

No changeset bc no change to functionality

💯
