### PR TITLE
fix: fixing typo in '@link', using '@see' in trpc base template file.

### DIFF
--- a/cli/template/extras/src/server/api/trpc/base.ts
+++ b/cli/template/extras/src/server/api/trpc/base.ts
@@ -39,7 +39,7 @@ const createInnerTRPCContext = async (_opts: CreateContextOptions) => {
 /**
  * This is the actual context you'll use in your router. It will be used to
  * process every request that goes through your tRPC endpoint
- * @link https://trpc.io/docs/context
+ * @see https://trpc.io/docs/context
  */
 export const createTRPCContext = async (_opts: CreateNextContextOptions) => {
   return await createInnerTRPCContext({});


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- see : https://github.com/prashantrahul141/create-t3-app/commit/42bb64575973e385a5c221f715154136a6b70f64 
   using `@see` instead of `@link` in comments referencing to the docs in the trpc base template file. https://github.com/t3-oss/create-t3-app/blob/020209c32f15ae0753632ee09ae02f8c0abda346/cli/template/extras/src/server/api/trpc/base.ts#L42 


---

## Screenshots

`@link` does not highlight links in editors ( example vscode)
![image](https://user-images.githubusercontent.com/59825803/211007549-b2446b3b-7d19-4b85-99c2-e48761cfa544.png)

whereas `@see` does.
![image](https://user-images.githubusercontent.com/59825803/211007630-a40ebc37-ea70-4ce2-a371-02c511126f0c.png)


💯
