### PR TITLE
fix: update name prop before installing deps

### DIFF
--- a/.changeset/pink-rabbits-fetch.md
+++ b/.changeset/pink-rabbits-fetch.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: update `package.json->name` before installing dependencies.

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -45,12 +45,6 @@ const main = async () => {
     noInstall,
   });
 
-  if (!noInstall) {
-    await installDependencies({ projectDir });
-  }
-
-  logNextSteps({ projectName: appDir, packages: usePackages, noInstall });
-
   // Write name to package.json
   const pkgJson = fs.readJSONSync(
     path.join(projectDir, "package.json"),
@@ -64,6 +58,12 @@ const main = async () => {
   if (!noGit) {
     await initializeGit(projectDir);
   }
+
+  if (!noInstall) {
+    await installDependencies({ projectDir });
+  }
+
+  logNextSteps({ projectName: appDir, packages: usePackages, noInstall });
 
   process.exit(0);
 };


### PR DESCRIPTION
Closes #1053 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

`name` attribute doesn't get replaced with the project name in `package-lock.json`. Now it does.

---

![image](https://user-images.githubusercontent.com/59825803/211154149-79a31725-6dfd-4771-8599-52aca6f721f3.png)

