### PR TITLE
fix: cleanup context type in `initTRPC`

### DIFF
--- a/.changeset/neat-singers-teach.md
+++ b/.changeset/neat-singers-teach.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: cleanup context type in `initTRPC`

--- a/cli/src/installers/dependencyVersionMap.ts
+++ b/cli/src/installers/dependencyVersionMap.ts
@@ -20,10 +20,10 @@ export const dependencyVersionMap = {
   "@types/prettier": "^2.7.2",
 
   // tRPC
-  "@trpc/client": "^10.7.0",
-  "@trpc/server": "^10.7.0",
-  "@trpc/react-query": "^10.7.0",
-  "@trpc/next": "^10.7.0",
+  "@trpc/client": "^10.8.1",
+  "@trpc/server": "^10.8.1",
+  "@trpc/react-query": "^10.8.1",
+  "@trpc/next": "^10.8.1",
   "@tanstack/react-query": "^4.20.0",
   superjson: "1.9.1",
 } as const;

--- a/cli/template/extras/src/server/api/trpc/base.ts
+++ b/cli/template/extras/src/server/api/trpc/base.ts
@@ -54,14 +54,12 @@ export const createTRPCContext = (_opts: CreateNextContextOptions) => {
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 
-const t = initTRPC
-  .context<Awaited<ReturnType<typeof createTRPCContext>>>()
-  .create({
-    transformer: superjson,
-    errorFormatter({ shape }) {
-      return shape;
-    },
-  });
+const t = initTRPC.context<typeof createTRPCContext>().create({
+  transformer: superjson,
+  errorFormatter({ shape }) {
+    return shape;
+  },
+});
 
 /**
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)

--- a/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
@@ -67,14 +67,12 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 
-const t = initTRPC
-  .context<Awaited<ReturnType<typeof createTRPCContext>>>()
-  .create({
-    transformer: superjson,
-    errorFormatter({ shape }) {
-      return shape;
-    },
-  });
+const t = initTRPC.context<typeof createTRPCContext>().create({
+  transformer: superjson,
+  errorFormatter({ shape }) {
+    return shape;
+  },
+});
 
 /**
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)

--- a/cli/template/extras/src/server/api/trpc/with-auth.ts
+++ b/cli/template/extras/src/server/api/trpc/with-auth.ts
@@ -65,14 +65,12 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 
-const t = initTRPC
-  .context<Awaited<ReturnType<typeof createTRPCContext>>>()
-  .create({
-    transformer: superjson,
-    errorFormatter({ shape }) {
-      return shape;
-    },
-  });
+const t = initTRPC.context<typeof createTRPCContext>().create({
+  transformer: superjson,
+  errorFormatter({ shape }) {
+    return shape;
+  },
+});
 
 /**
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)

--- a/cli/template/extras/src/server/api/trpc/with-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-prisma.ts
@@ -55,14 +55,12 @@ export const createTRPCContext = (_opts: CreateNextContextOptions) => {
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
 
-const t = initTRPC
-  .context<Awaited<ReturnType<typeof createTRPCContext>>>()
-  .create({
-    transformer: superjson,
-    errorFormatter({ shape }) {
-      return shape;
-    },
-  });
+const t = initTRPC.context<typeof createTRPCContext>().create({
+  transformer: superjson,
+  errorFormatter({ shape }) {
+    return shape;
+  },
+});
 
 /**
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Made this addition in trpc 10.8: https://github.com/trpc/trpc/pull/3495

Cleans things up a bit not having to use `Awaited<ReturnType<>>`

---

## Screenshots

_[Screenshots]_

💯
