### PR TITLE
fix: "ONLY the parts you need" card height css

### DIFF
--- a/www/src/components/landingPage/stack/card.astro
+++ b/www/src/components/landingPage/stack/card.astro
@@ -24,7 +24,7 @@ const { title, href } = Astro.props;
       </p>
     </div>
     <div
-      class="m-6 h-full text-sm text-t3-purple-100 subpixel-antialiased md:text-base"
+      class="m-6 text-sm text-t3-purple-100 subpixel-antialiased md:text-base"
     >
       <slot name="description" />
     </div>


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

On "ONLY the parts you need" section those card's are taking extra height
and card are hovered (+clickable) while cursor are not on those card.

---

## Screenshots

![Screenshot](https://user-images.githubusercontent.com/62445940/211537260-2dbfab7a-4f5a-4d20-93ba-1ef693a2300f.png)

💯
