### PR TITLE
fix(doc): a styling issue of the inline code blocks

### DIFF
--- a/www/src/components/docs/pageContent.astro
+++ b/www/src/components/docs/pageContent.astro
@@ -226,6 +226,7 @@ const isRtl = getIsRtlFromLangCode((lang || "en") as KnownLanguageCode);
 
     codeElements.forEach((codeElement) => {
       const codeWrapper = document.createElement("div");
+      codeWrapper.classList.add("inline-block");
       codeElement.parentNode?.insertBefore(codeWrapper, codeElement);
 
       codeWrapper.appendChild(codeElement);


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Before this fix, the inline code blocks were wrapped in a `div`, so they were placed on new lines. These line breaks made the documentation harder to read, so I applied the `inline-block` TW classes to them (could've been `inline` too, but I thought that maybe the `block`-aspect of the positioning is important, otherwise a `span`-element would've been used).

---

## Screenshots

**Before**
<img width="728" alt="image" src="https://user-images.githubusercontent.com/43729152/213412268-51bcd07a-a13a-4979-a13f-336cd39e2067.png">

**After**
<img width="740" alt="image" src="https://user-images.githubusercontent.com/43729152/213412412-683c6852-56cb-4cb3-a6a3-337e99241a0c.png">

_[Screenshots]_

💯
