### PR TITLE
fix: code wrapper not applying styles in firefox

### DIFF
--- a/www/src/components/docs/pageContent.astro
+++ b/www/src/components/docs/pageContent.astro
@@ -226,7 +226,7 @@ const isRtl = getIsRtlFromLangCode((lang || "en") as KnownLanguageCode);
 
     codeElements.forEach((codeElement) => {
       const codeWrapper = document.createElement("div");
-      codeWrapper.classList.add("inline-block");
+      codeWrapper.classList.add("inline-block", "code-wrapper");
       codeElement.parentNode?.insertBefore(codeWrapper, codeElement);
 
       codeWrapper.appendChild(codeElement);

--- a/www/src/styles/global.css
+++ b/www/src/styles/global.css
@@ -180,15 +180,15 @@
           dark:decoration-t3-purple-200 dark:hover:text-t3-purple-300;
   }
 
-  :is([dir='rtl']) .markdown a[rel~="noreferrer"] > span {
-    @apply -scale-x-100 inline-flex;
-}
+  :is([dir="rtl"]) .markdown a[rel~="noreferrer"] > span {
+    @apply inline-flex -scale-x-100;
+  }
 
   .markdown code {
     @apply break-words [direction:ltr] [unicode-bidi:embed] lg:break-normal;
   }
 
-  .markdown div:has( > code) {
+  .markdown .code-wrapper {
     @apply inline rounded border border-t3-purple-200 bg-t3-purple-200/40 px-0.5 py-[0.5px] dark:border-t3-purple-400/30 dark:bg-t3-purple-400/20;
   }
 


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

the `:has()` selector is not yet enabled in FireFox by default, see: https://caniuse.com/css-has

so instead this PR applies a class to the code wrapper div and styles that. tested in both ltr and rtl.

---

## Screenshots

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/8353666/213470783-96af22b2-891e-4c30-b1c4-9c6acaea6874.png">

💯
