### PR TITLE
fix: fetch contributors from correct path

### DIFF
--- a/www/src/pages/ar/folder-structure.mdx
+++ b/www/src/pages/ar/folder-structure.mdx
@@ -4,6 +4,7 @@ description: بنية مجلد T3 App
 layout: ../../layouts/docs.astro
 lang: ar
 dir: rtl
+isMdx: true
 ---
 
 import Form from "../../components/docs/folderStructureForm.astro";
@@ -206,7 +207,7 @@ import Diagram from "../../components/docs/folderStructureDiagram.astro";
 
 ### `prettier.config.cjs`
 
-إن ملف `prettier.config.cjs` ضروري عند استخدام  Prettier ولإضافة prettier-plugin-tailwindcss لتنظيم الفئات (classes) مع Tailwind CSS، لمزيد من المعلومات [Tailwind CSS blog post](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier).
+إن ملف `prettier.config.cjs` ضروري عند استخدام Prettier ولإضافة prettier-plugin-tailwindcss لتنظيم الفئات (classes) مع Tailwind CSS، لمزيد من المعلومات [Tailwind CSS blog post](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier).
 
 </div>
 <div>

--- a/www/src/pages/en/folder-structure.mdx
+++ b/www/src/pages/en/folder-structure.mdx
@@ -3,6 +3,7 @@ title: Folder Structure
 description: Folder structure of a newly scaffolded T3 App
 layout: ../../layouts/docs.astro
 lang: en
+isMdx: true
 ---
 
 import Form from "../../components/docs/folderStructureForm.astro";

--- a/www/src/pages/fr/folder-structure.mdx
+++ b/www/src/pages/fr/folder-structure.mdx
@@ -3,6 +3,7 @@ title: Structure des dossiers
 description: Structure des dossiers d'une application T3 nouvellement créée
 layout: ../../layouts/docs.astro
 lang: fr
+isMdx: true
 ---
 
 import Form from "../../components/docs/folderStructureForm.astro";

--- a/www/src/pages/pl/folder-structure.mdx
+++ b/www/src/pages/pl/folder-structure.mdx
@@ -3,6 +3,7 @@ title: Struktura projektu
 description: Struktura projektu nowej aplikacji T3
 layout: ../../layouts/docs.astro
 lang: pl
+isMdx: true
 ---
 
 import Form from "../../components/docs/folderStructureForm.astro";

--- a/www/src/pages/ru/folder-structure.mdx
+++ b/www/src/pages/ru/folder-structure.mdx
@@ -3,6 +3,7 @@ title: Файловая структура
 description: Файловая структура нового T3 приложения
 layout: ../../layouts/docs.astro
 lang: ru
+isMdx: true
 ---
 
 import Form from "../../components/docs/folderStructureForm.astro";

--- a/www/src/pages/zh-hans/folder-structure.mdx
+++ b/www/src/pages/zh-hans/folder-structure.mdx
@@ -3,6 +3,7 @@ title: 文件夹结构
 description: 新创建的 T3 App 的文件夹结构
 layout: ../../layouts/docs.astro
 lang: zh-hans
+isMdx: true
 ---
 
 import Form from "../../components/docs/folderStructureForm.astro";


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Updates frontmatter of `.mdx` markdown files so that the footer fetches and links to correct github page.

💯
