### PR TITLE
fix(doc): Fix the broken styling of the code blocks

### DIFF
--- a/www/src/components/docs/pageContent.astro
+++ b/www/src/components/docs/pageContent.astro
@@ -221,12 +221,13 @@ const isRtl = getIsRtlFromLangCode((lang || "en") as KnownLanguageCode);
 </script>
 <script>
   const main = () => {
-    const notACodeBlock = ":not(pre) code";
-    const codeElements = document.querySelectorAll(notACodeBlock);
+    const codeElements = Array.from(document.querySelectorAll("code")).filter(
+      (codeElement) => codeElement.parentNode?.nodeName !== "PRE",
+    );
 
     codeElements.forEach((codeElement) => {
       const codeWrapper = document.createElement("div");
-      codeWrapper.classList.add("inline-block", "code-wrapper");
+      codeWrapper.classList.add("code-wrapper");
       codeElement.parentNode?.insertBefore(codeWrapper, codeElement);
 
       codeWrapper.appendChild(codeElement);


### PR DESCRIPTION
Fixes #1100 (which is currently closed, but not entirely fixed: https://github.com/t3-oss/create-t3-app/issues/1100#issuecomment-1398209883)

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

#1102 accidentally broke the styling of the code blocks (`code` elements inside of `pre`), because of a broken selector.

This part in `www/src/components/docs/pageContent.astro` selects **all** code blocks (including the children of `pre` elements) and applies the `.code-wrapper` class to them, hence the light background and double border:

```typescript
    const notACodeBlock = ":not(pre) code";
    const codeElements = document.querySelectorAll(notACodeBlock);
```

#1102 is a good fix to the issue it addressed btw, the was already broken. ☺️ 

---

## Screenshots

**Before**
<img width="735" alt="image" src="https://user-images.githubusercontent.com/43729152/213676536-a1d58487-f8b0-4890-91d4-f496d503ea37.png">

**After**
<img width="739" alt="image" src="https://user-images.githubusercontent.com/43729152/213678689-3bbd1449-eba6-44b2-a833-d01dec1be395.png">


https://create.t3.gg/en/usage/prisma#seeding-your-database

💯
