### PR TITLE
refactor: replaced VERCEL with VERCEL_URL in serverSchema for consistency

### DIFF
--- a/cli/template/extras/src/env/schema/with-auth-prisma.mjs
+++ b/cli/template/extras/src/env/schema/with-auth-prisma.mjs
@@ -17,7 +17,7 @@ export const serverSchema = z.object({
     // Since NextAuth.js automatically uses the VERCEL_URL if present.
     (str) => process.env.VERCEL_URL ?? str,
     // VERCEL_URL doesn't include `https` so it cant be validated as a URL
-    process.env.VERCEL ? z.string() : z.string().url(),
+    process.env.VERCEL_URL ? z.string() : z.string().url(),
   ),
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),

--- a/cli/template/extras/src/env/schema/with-auth.mjs
+++ b/cli/template/extras/src/env/schema/with-auth.mjs
@@ -16,7 +16,7 @@ export const serverSchema = z.object({
     // Since NextAuth.js automatically uses the VERCEL_URL if present.
     (str) => process.env.VERCEL_URL ?? str,
     // VERCEL_URL doesn't include `https` so it cant be validated as a URL
-    process.env.VERCEL ? z.string() : z.string().url(),
+    process.env.VERCEL_URL ? z.string() : z.string().url(),
   ),
   DISCORD_CLIENT_ID: z.string(),
   DISCORD_CLIENT_SECRET: z.string(),


### PR DESCRIPTION
Closes #1108

## ✅ Checklist

- [✅ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [ ✅] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Replaced all instances of environment variable named **VERCEL** to **VERCEL_URL** used in **zod** validation object for **serverSchema**.

---

## Screenshots

Before:-

![old](https://user-images.githubusercontent.com/82873939/213841786-16eb0fcb-2375-4ce2-9d06-84a8baea9fff.png)

After:-

![new](https://user-images.githubusercontent.com/82873939/213841796-10edf1bd-f25e-4cf4-90ee-250b222a8c76.png)



💯
