### PR TITLE
docs: Add option to contribute via Codesandbox

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -68,26 +68,6 @@
       "name": "format:check",
       "command": "pnpm format:check",
       "runAtStart": false
-    },
-    "check": {
-      "name": "check",
-      "command": "pnpm check",
-      "runAtStart": false
-    },
-    "release": {
-      "name": "release",
-      "command": "pnpm release",
-      "runAtStart": false
-    },
-    "pub:beta": {
-      "name": "pub:beta",
-      "command": "pnpm pub:beta",
-      "runAtStart": false
-    },
-    "pub:release": {
-      "name": "pub:release",
-      "command": "pnpm pub:release",
-      "runAtStart": false
     }
   }
 }

--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -1,0 +1,93 @@
+{
+  // These tasks will run in order when initializing your CodeSandbox project.
+  "setupTasks": [
+    {
+      "name": "Install Dependencies",
+      "command": "pnpm install"
+    }
+  ],
+
+  // These tasks can be run from CodeSandbox. Running one will open a log in the app.
+  "tasks": {
+    "typecheck": {
+      "name": "typecheck",
+      "command": "pnpm typecheck",
+      "runAtStart": false
+    },
+    "build:cli": {
+      "name": "build:cli",
+      "command": "pnpm build:cli",
+      "runAtStart": false
+    },
+    "build:www": {
+      "name": "build:www",
+      "command": "pnpm build:www",
+      "runAtStart": false
+    },
+    "build": {
+      "name": "build",
+      "command": "pnpm build",
+      "runAtStart": false
+    },
+    "start:cli": {
+      "name": "start:cli",
+      "command": "pnpm start:cli",
+      "runAtStart": false
+    },
+    "start:www": {
+      "name": "start:www",
+      "command": "pnpm start:www",
+      "runAtStart": false
+    },
+    "dev:cli": {
+      "name": "dev:cli",
+      "command": "pnpm dev:cli",
+      "runAtStart": false
+    },
+    "dev:www": {
+      "name": "dev:www",
+      "command": "pnpm dev:www",
+      "runAtStart": true
+    },
+    "clean": {
+      "name": "clean",
+      "command": "pnpm clean",
+      "runAtStart": false
+    },
+    "lint": {
+      "name": "lint",
+      "command": "pnpm lint",
+      "runAtStart": false
+    },
+    "format": {
+      "name": "format",
+      "command": "pnpm format",
+      "runAtStart": false
+    },
+    "format:check": {
+      "name": "format:check",
+      "command": "pnpm format:check",
+      "runAtStart": false
+    },
+    "check": {
+      "name": "check",
+      "command": "pnpm check",
+      "runAtStart": false
+    },
+    "release": {
+      "name": "release",
+      "command": "pnpm release",
+      "runAtStart": false
+    },
+    "pub:beta": {
+      "name": "pub:beta",
+      "command": "pnpm pub:beta",
+      "runAtStart": false
+    },
+    "pub:release": {
+      "name": "pub:release",
+      "command": "pnpm pub:release",
+      "runAtStart": false
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,19 @@ When contributing to `create-t3-app`, whether on GitHub or in other community sp
 - Before opening a new pull request, try searching through the [issue tracker](https://github.com/nexxeln/create-t3-app/issues) for known issues or fixes.
 - If you want to make code changes based on your personal opinion(s), make sure you open an issue first describing the changes you want to make, and open a pull request only when your suggestions get approved by maintainers.
 
+
+
 ## How to Contribute
 
 ### Prerequisites
 
 In order to not waste your time implementing a change that has already been declined, or is generally not needed, start by [opening an issue](https://github.com/t3-oss/create-t3-app/issues/new/choose) describing the problem you would like to solve.
 
-### Setup your environment
+### Contributing via Codesanbox 
+
+You can contribute to this documentation on codesandbox which will automatically run all the setup command for you. [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/github/t3-oss/create-t3-app)
+
+### Setup your environment locally
 
 _Some commands will assume you have the Github CLI installed, if you haven't, consider [installing it](https://github.com/cli/cli#installation), but you can always use the Web UI if you prefer that instead._
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,17 +6,15 @@ When contributing to `create-t3-app`, whether on GitHub or in other community sp
 - Before opening a new pull request, try searching through the [issue tracker](https://github.com/nexxeln/create-t3-app/issues) for known issues or fixes.
 - If you want to make code changes based on your personal opinion(s), make sure you open an issue first describing the changes you want to make, and open a pull request only when your suggestions get approved by maintainers.
 
-
-
 ## How to Contribute
 
 ### Prerequisites
 
 In order to not waste your time implementing a change that has already been declined, or is generally not needed, start by [opening an issue](https://github.com/t3-oss/create-t3-app/issues/new/choose) describing the problem you would like to solve.
 
-### Contributing via Codesanbox 
+### Contributing via Codesanbox
 
-You can contribute to this documentation on codesandbox which will automatically run all the setup command for you. [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/github/t3-oss/create-t3-app)
+You can contribute to this documentation on codesandbox which will automatically run all the setup command for you. [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/github/t3-oss/create-t3-app).
 
 ### Setup your environment locally
 


### PR DESCRIPTION
Closes #<issue>

This PR adds the edit with codesandbox option for contributing to create-T3-app. The benefits of this includes having :
- Setting up repository in codesandbox in seconds as shown in Screen recoding 
- Seemless branching and main branch protection 
- Command checklist is automatically added to a `task.json` file and exected in order. This  avoids errors when setting up the repo.  

Codesandbox also has a [Template for create-T3-app](https://codesandbox.io/p/sandbox/sharp-euclid-6k4sdn) running on Cloud sandboxes powered by micro VMs

https://codesandbox.io/p/sandbox/sharp-euclid-6k4sdn


## ✅ Checklist

- [ x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [ x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

_[Short description of what has changed]_

---

## Screenshots

_[Screenshots]_

💯

https://user-images.githubusercontent.com/35943047/214197882-bb5b7f8b-8e96-48d6-b247-a19949679a02.mov

