### PR TITLE
fix: improve readability of gh stars counter

### DIFF
--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -27,7 +27,7 @@ const isRtl = getIsRtlFromUrl(pathname);
   <div
     id="github-star"
     class={clsx(
-      "relative ltr:mr-[.33em] rtl:ml-[.33em] hidden md:flex items-center bg-clip-padding rounded-lg no-underline border-t3-purple-200/50 group-hover:border-t3-purple-200/75 bg-t3-purple-200/50 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:group-hover:bg-t3-purple-200/10 group-hover:bg-t3-purple-200/75 dark:group-hover:border-t3-purple-200/50 transition-colors duration-300 p-1 text-slate-800 dark:text-slate-100",
+      "relative ltr:mr-[.33em] rtl:ml-[.33em] hidden md:flex items-center bg-clip-padding rounded-lg no-underline border-t3-purple-200/50 group-hover:border-t3-purple-200/75 bg-t3-purple-200/50 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:group-hover:bg-t3-purple-200/10 group-hover:bg-t3-purple-200/75 dark:group-hover:border-t3-purple-200/50 transition-colors duration-300 py-1 px-2 text-slate-800 dark:text-slate-100",
       [
         /** triangle arrow */
         "after:absolute after:h-0 after:w-0 after:border-8 after:border-transparent after:transition-colors after:duration-300",
@@ -47,7 +47,7 @@ const isRtl = getIsRtlFromUrl(pathname);
         d="M316.9 18C311.6 7 300.4 0 288.1 0s-23.4 7-28.8 18L195 150.3 51.4 171.5c-12 1.8-22 10.2-25.7 21.7s-.7 24.2 7.9 32.7L137.8 329 113.2 474.7c-2 12 3 24.2 12.9 31.3s23 8 33.8 2.3l128.3-68.5 128.3 68.5c10.8 5.7 23.9 4.9 33.8-2.3s14.9-19.3 12.9-31.3L438.5 329 542.7 225.9c8.6-8.5 11.7-21.2 7.9-32.7s-13.7-19.9-25.7-21.7L381.2 150.3 316.9 18z"
       ></path>
     </svg>
-    {githubStars}
+    {Intl.NumberFormat().format(githubStars)}
   </div>
   <svg
     role="img"


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The current PR aims to use punctuation and format the GitHub stars counter in order to reduce ambiguity and improve readability and comprehension as reported in the [_Web Accessibility Initiative (WAI)_](https://www.w3.org/WAI/)

---

## Screenshots

| **Before** |<img width="1276" alt="Screenshot 2023-01-26 at 01 23 34" src="https://user-images.githubusercontent.com/16477661/214726126-9d5cd6cb-e576-4f92-90de-2f0ec20d1e4d.png">|
|---|:---:|
| **After** |<img width="1276" alt="Screenshot 2023-01-26 at 01 23 23" src="https://user-images.githubusercontent.com/16477661/214726168-91b73af0-80ff-47f9-8567-4c7cfbf732bb.png">|

💯
