### PR TITLE
fix: typos

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -542,7 +542,7 @@
 - **cli:** use correct spelling, fix short choices ([7776aa9](https://github.com/t3-oss/create-t3-app/commit/7776aa9fc03293f27d9e27808cd03810f96ccc33))
 - conditionally run envVars installer ([#196](https://github.com/t3-oss/create-t3-app/issues/196)) ([f5f4f62](https://github.com/t3-oss/create-t3-app/commit/f5f4f6275c1a967f6de2e7c6d40d9a7731a3830b))
 - docs wrong format ([3d2dbb0](https://github.com/t3-oss/create-t3-app/commit/3d2dbb06cadb42d24f134ce09edc5a371d79aff9))
-- dont prompt for typesafe env-vars ([2faee56](https://github.com/t3-oss/create-t3-app/commit/2faee56720c39d770ebe05d15e3fb2aaacaf704e))
+- don't prompt for typesafe env-vars ([2faee56](https://github.com/t3-oss/create-t3-app/commit/2faee56720c39d770ebe05d15e3fb2aaacaf704e))
 - eslint warning (import/no-anonymous-default-export) ([a1cce55](https://github.com/t3-oss/create-t3-app/commit/a1cce5546a8fd6efb79c65a2f2b52d4c597dafd0))
 - fixed some typos ([#131](https://github.com/t3-oss/create-t3-app/issues/131)) ([a86466e](https://github.com/t3-oss/create-t3-app/commit/a86466eb0bc1ef51a1c8ba1b96938dc1bd7dfbbb))
 - format contributing.md ([4111476](https://github.com/t3-oss/create-t3-app/commit/41114766582ca33fb2a3fd0b566e609a6dd3e861))

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -230,7 +230,7 @@ const promptPackages = async (): Promise<AvailablePackages[]> => {
     type: "checkbox",
     message: "Which packages would you like to enable?",
     choices: availablePackages
-      .filter((pkg) => pkg !== "envVariables") // dont prompt for env-vars
+      .filter((pkg) => pkg !== "envVariables") // don't prompt for env-vars
       .map((pkgName) => ({
         name: pkgName,
         checked: false,

--- a/cli/template/base/next.config.mjs
+++ b/cli/template/base/next.config.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+
 /**
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.
  * This is especially useful for Docker builds.
@@ -8,8 +9,13 @@
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,
-  /* If trying out the experimental appDir, comment the i18n config out
-   * @see https://github.com/vercel/next.js/issues/41980 */
+
+  /**
+   * If you have the "experimental: { appDir: true }" setting enabled, then you
+   * must comment the below `i18n` config out.
+   *
+   * @see https://github.com/vercel/next.js/issues/41980
+   */
   i18n: {
     locales: ["en"],
     defaultLocale: "en",

--- a/cli/template/extras/src/server/api/trpc/base.ts
+++ b/cli/template/extras/src/server/api/trpc/base.ts
@@ -72,6 +72,7 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
 
 /**
  * This is how you create new routers and sub-routers in your tRPC API.
+ *
  * @see https://trpc.io/docs/router
  */
 export const createTRPCRouter = t.router;

--- a/cli/template/extras/src/server/api/trpc/base.ts
+++ b/cli/template/extras/src/server/api/trpc/base.ts
@@ -1,35 +1,36 @@
 /**
  * YOU PROBABLY DON'T NEED TO EDIT THIS FILE, UNLESS:
- * 1. You want to modify request context (see Part 1)
- * 2. You want to create a new middleware or type of procedure (see Part 3)
+ * 1. You want to modify request context (see Part 1).
+ * 2. You want to create a new middleware or type of procedure (see Part 3).
  *
- * tl;dr - this is where all the tRPC server stuff is created and plugged in.
- * The pieces you will need to use are documented accordingly near the end
+ * tl;dr - This is where all the tRPC server stuff is created and plugged in.
+ * The pieces you will need to use are documented accordingly near the end.
  */
 
 /**
  * 1. CONTEXT
  *
- * This section defines the "contexts" that are available in the backend API
+ * This section defines the "contexts" that are available in the backend API.
  *
- * These allow you to access things like the database, the session, etc, when
- * processing a request
- *
+ * These allow you to access things when processing a request, like the
+ * database, the session, etc.
  */
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 
 /**
- * Replace this with an object if you want to pass things to createContextInner
+ * Replace this with an object if you want to pass things to
+ * `createContextInner`.
  */
 type CreateContextOptions = Record<string, never>;
 
 /**
  * This helper generates the "internals" for a tRPC context. If you need to use
- * it, you can export it from here
+ * it, you can export it from here.
  *
  * Examples of things you may need it for:
  * - testing, so we don't have to mock Next.js' req/res
- * - trpc's `createSSGHelpers` where we don't have req/res
+ * - tRPC's `createSSGHelpers`, where we don't have req/res
+ *
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */
 const createInnerTRPCContext = (_opts: CreateContextOptions) => {
@@ -37,8 +38,9 @@ const createInnerTRPCContext = (_opts: CreateContextOptions) => {
 };
 
 /**
- * This is the actual context you'll use in your router. It will be used to
- * process every request that goes through your tRPC endpoint
+ * This is the actual context you will use in your router. It will be used to
+ * process every request that goes through your tRPC endpoint.
+ *
  * @see https://trpc.io/docs/context
  */
 export const createTRPCContext = (_opts: CreateNextContextOptions) => {
@@ -48,8 +50,8 @@ export const createTRPCContext = (_opts: CreateNextContextOptions) => {
 /**
  * 2. INITIALIZATION
  *
- * This is where the trpc api is initialized, connecting the context and
- * transformer
+ * This is where the tRPC API is initialized, connecting the context and
+ * transformer.
  */
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
@@ -65,20 +67,20 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)
  *
  * These are the pieces you use to build your tRPC API. You should import these
- * a lot in the /src/server/api/routers folder
+ * a lot in the "/src/server/api/routers" directory.
  */
 
 /**
- * This is how you create new routers and subrouters in your tRPC API
+ * This is how you create new routers and sub-routers in your tRPC API.
  * @see https://trpc.io/docs/router
  */
 export const createTRPCRouter = t.router;
 
 /**
- * Public (unauthed) procedure
+ * Public (unauthenticated) procedure
  *
  * This is the base piece you use to build new queries and mutations on your
  * tRPC API. It does not guarantee that a user querying is authorized, but you
- * can still access user session data if they are logged in
+ * can still access user session data if they are logged in.
  */
 export const publicProcedure = t.procedure;

--- a/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
@@ -84,6 +84,7 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
 
 /**
  * This is how you create new routers and sub-routers in your tRPC API.
+ *
  * @see https://trpc.io/docs/router
  */
 export const createTRPCRouter = t.router;

--- a/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
@@ -31,7 +31,7 @@ type CreateContextOptions = {
  * it, you can export it from here
  *
  * Examples of things you may need it for:
- * - testing, so we dont have to mock Next.js' req/res
+ * - testing, so we don't have to mock Next.js' req/res
  * - trpc's `createSSGHelpers` where we don't have req/res
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */

--- a/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-auth-prisma.ts
@@ -1,20 +1,19 @@
 /**
  * YOU PROBABLY DON'T NEED TO EDIT THIS FILE, UNLESS:
- * 1. You want to modify request context (see Part 1)
- * 2. You want to create a new middleware or type of procedure (see Part 3)
+ * 1. You want to modify request context (see Part 1).
+ * 2. You want to create a new middleware or type of procedure (see Part 3).
  *
- * tl;dr - this is where all the tRPC server stuff is created and plugged in.
- * The pieces you will need to use are documented accordingly near the end
+ * tl;dr - This is where all the tRPC server stuff is created and plugged in.
+ * The pieces you will need to use are documented accordingly near the end.
  */
 
 /**
  * 1. CONTEXT
  *
- * This section defines the "contexts" that are available in the backend API
+ * This section defines the "contexts" that are available in the backend API.
  *
- * These allow you to access things like the database, the session, etc, when
- * processing a request
- *
+ * These allow you to access things when processing a request, like the
+ * database, the session, etc.
  */
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 import { type Session } from "next-auth";
@@ -28,11 +27,12 @@ type CreateContextOptions = {
 
 /**
  * This helper generates the "internals" for a tRPC context. If you need to use
- * it, you can export it from here
+ * it, you can export it from here.
  *
  * Examples of things you may need it for:
  * - testing, so we don't have to mock Next.js' req/res
- * - trpc's `createSSGHelpers` where we don't have req/res
+ * - tRPC's `createSSGHelpers`, where we don't have req/res
+ *
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */
 const createInnerTRPCContext = (opts: CreateContextOptions) => {
@@ -43,9 +43,10 @@ const createInnerTRPCContext = (opts: CreateContextOptions) => {
 };
 
 /**
- * This is the actual context you'll use in your router. It will be used to
- * process every request that goes through your tRPC endpoint
- * @link https://trpc.io/docs/context
+ * This is the actual context you will use in your router. It will be used to
+ * process every request that goes through your tRPC endpoint.
+ *
+ * @see https://trpc.io/docs/context
  */
 export const createTRPCContext = async (opts: CreateNextContextOptions) => {
   const { req, res } = opts;
@@ -61,8 +62,8 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
 /**
  * 2. INITIALIZATION
  *
- * This is where the trpc api is initialized, connecting the context and
- * transformer
+ * This is where the tRPC API is initialized, connecting the context and
+ * transformer.
  */
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
@@ -78,27 +79,27 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)
  *
  * These are the pieces you use to build your tRPC API. You should import these
- * a lot in the /src/server/api/routers folder
+ * a lot in the "/src/server/api/routers" directory.
  */
 
 /**
- * This is how you create new routers and subrouters in your tRPC API
+ * This is how you create new routers and sub-routers in your tRPC API.
  * @see https://trpc.io/docs/router
  */
 export const createTRPCRouter = t.router;
 
 /**
- * Public (unauthed) procedure
+ * Public (unauthenticated) procedure
  *
  * This is the base piece you use to build new queries and mutations on your
  * tRPC API. It does not guarantee that a user querying is authorized, but you
- * can still access user session data if they are logged in
+ * can still access user session data if they are logged in.
  */
 export const publicProcedure = t.procedure;
 
 /**
  * Reusable middleware that enforces users are logged in before running the
- * procedure
+ * procedure.
  */
 const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
   if (!ctx.session || !ctx.session.user) {
@@ -113,11 +114,11 @@ const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
 });
 
 /**
- * Protected (authed) procedure
+ * Protected (authenticated) procedure
  *
  * If you want a query or mutation to ONLY be accessible to logged in users, use
- * this. It verifies the session is valid and guarantees ctx.session.user is not
- * null
+ * this. It verifies the session is valid and guarantees `ctx.session.user` is
+ * not null.
  *
  * @see https://trpc.io/docs/procedures
  */

--- a/cli/template/extras/src/server/api/trpc/with-auth.ts
+++ b/cli/template/extras/src/server/api/trpc/with-auth.ts
@@ -1,20 +1,19 @@
 /**
  * YOU PROBABLY DON'T NEED TO EDIT THIS FILE, UNLESS:
- * 1. You want to modify request context (see Part 1)
- * 2. You want to create a new middleware or type of procedure (see Part 3)
+ * 1. You want to modify request context (see Part 1).
+ * 2. You want to create a new middleware or type of procedure (see Part 3).
  *
- * tl;dr - this is where all the tRPC server stuff is created and plugged in.
- * The pieces you will need to use are documented accordingly near the end
+ * tl;dr - This is where all the tRPC server stuff is created and plugged in.
+ * The pieces you will need to use are documented accordingly near the end.
  */
 
 /**
  * 1. CONTEXT
  *
- * This section defines the "contexts" that are available in the backend API
+ * This section defines the "contexts" that are available in the backend API.
  *
- * These allow you to access things like the database, the session, etc, when
- * processing a request
- *
+ * These allow you to access things when processing a request, like the
+ * database, the session, etc.
  */
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 import { type Session } from "next-auth";
@@ -27,11 +26,12 @@ type CreateContextOptions = {
 
 /**
  * This helper generates the "internals" for a tRPC context. If you need to use
- * it, you can export it from here
+ * it, you can export it from here.
  *
  * Examples of things you may need it for:
  * - testing, so we don't have to mock Next.js' req/res
- * - trpc's `createSSGHelpers` where we don't have req/res
+ * - tRPC's `createSSGHelpers`, where we don't have req/res
+ *
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */
 const createInnerTRPCContext = (opts: CreateContextOptions) => {
@@ -41,9 +41,10 @@ const createInnerTRPCContext = (opts: CreateContextOptions) => {
 };
 
 /**
- * This is the actual context you'll use in your router. It will be used to
- * process every request that goes through your tRPC endpoint
- * @link https://trpc.io/docs/context
+ * This is the actual context you will use in your router. It will be used to
+ * process every request that goes through your tRPC endpoint.
+ *
+ * @see https://trpc.io/docs/context
  */
 export const createTRPCContext = async (opts: CreateNextContextOptions) => {
   const { req, res } = opts;
@@ -59,8 +60,8 @@ export const createTRPCContext = async (opts: CreateNextContextOptions) => {
 /**
  * 2. INITIALIZATION
  *
- * This is where the trpc api is initialized, connecting the context and
- * transformer
+ * This is where the tRPC API is initialized, connecting the context and
+ * transformer.
  */
 import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
@@ -76,27 +77,28 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)
  *
  * These are the pieces you use to build your tRPC API. You should import these
- * a lot in the /src/server/api/routers folder
+ * a lot in the "/src/server/api/routers" directory.
  */
 
 /**
- * This is how you create new routers and subrouters in your tRPC API
+ * This is how you create new routers and sub-routers in your tRPC API.
+ *
  * @see https://trpc.io/docs/router
  */
 export const createTRPCRouter = t.router;
 
 /**
- * Public (unauthed) procedure
+ * Public (unauthenticated) procedure
  *
  * This is the base piece you use to build new queries and mutations on your
  * tRPC API. It does not guarantee that a user querying is authorized, but you
- * can still access user session data if they are logged in
+ * can still access user session data if they are logged in.
  */
 export const publicProcedure = t.procedure;
 
 /**
  * Reusable middleware that enforces users are logged in before running the
- * procedure
+ * procedure.
  */
 const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
   if (!ctx.session || !ctx.session.user) {
@@ -111,11 +113,11 @@ const enforceUserIsAuthed = t.middleware(({ ctx, next }) => {
 });
 
 /**
- * Protected (authed) procedure
+ * Protected (authenticated) procedure
  *
  * If you want a query or mutation to ONLY be accessible to logged in users, use
- * this. It verifies the session is valid and guarantees ctx.session.user is not
- * null
+ * this. It verifies the session is valid and guarantees `ctx.session.user` is
+ * not null.
  *
  * @see https://trpc.io/docs/procedures
  */

--- a/cli/template/extras/src/server/api/trpc/with-auth.ts
+++ b/cli/template/extras/src/server/api/trpc/with-auth.ts
@@ -30,7 +30,7 @@ type CreateContextOptions = {
  * it, you can export it from here
  *
  * Examples of things you may need it for:
- * - testing, so we dont have to mock Next.js' req/res
+ * - testing, so we don't have to mock Next.js' req/res
  * - trpc's `createSSGHelpers` where we don't have req/res
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */

--- a/cli/template/extras/src/server/api/trpc/with-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-prisma.ts
@@ -1,20 +1,19 @@
 /**
  * YOU PROBABLY DON'T NEED TO EDIT THIS FILE, UNLESS:
- * 1. You want to modify request context (see Part 1)
- * 2. You want to create a new middleware or type of procedure (see Part 3)
+ * 1. You want to modify request context (see Part 1).
+ * 2. You want to create a new middleware or type of procedure (see Part 3).
  *
- * tl;dr - this is where all the tRPC server stuff is created and plugged in.
- * The pieces you will need to use are documented accordingly near the end
+ * tl;dr - This is where all the tRPC server stuff is created and plugged in.
+ * The pieces you will need to use are documented accordingly near the end.
  */
 
 /**
  * 1. CONTEXT
  *
- * This section defines the "contexts" that are available in the backend API
+ * This section defines the "contexts" that are available in the backend API.
  *
- * These allow you to access things like the database, the session, etc, when
- * processing a request
- *
+ * These allow you to access things when processing a request, like the
+ * database, the session, etc.
  */
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 
@@ -24,11 +23,11 @@ type CreateContextOptions = Record<string, never>;
 
 /**
  * This helper generates the "internals" for a tRPC context. If you need to use
- * it, you can export it from here
+ * it, you can export it from here.
  *
  * Examples of things you may need it for:
  * - testing, so we don't have to mock Next.js' req/res
- * - trpc's `createSSGHelpers` where we don't have req/res
+ * - trpc's `createSSGHelpers`, where we don't have req/res
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */
 const createInnerTRPCContext = (_opts: CreateContextOptions) => {
@@ -38,9 +37,9 @@ const createInnerTRPCContext = (_opts: CreateContextOptions) => {
 };
 
 /**
- * This is the actual context you'll use in your router. It will be used to
- * process every request that goes through your tRPC endpoint
- * @link https://trpc.io/docs/context
+ * This is the actual context you will use in your router. It will be used to
+ * process every request that goes through your tRPC endpoint.
+ * @see https://trpc.io/docs/context
  */
 export const createTRPCContext = (_opts: CreateNextContextOptions) => {
   return createInnerTRPCContext({});
@@ -49,8 +48,8 @@ export const createTRPCContext = (_opts: CreateNextContextOptions) => {
 /**
  * 2. INITIALIZATION
  *
- * This is where the trpc api is initialized, connecting the context and
- * transformer
+ * This is where the tRPC API is initialized, connecting the context and
+ * transformer.
  */
 import { initTRPC } from "@trpc/server";
 import superjson from "superjson";
@@ -66,20 +65,20 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
  * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)
  *
  * These are the pieces you use to build your tRPC API. You should import these
- * a lot in the /src/server/api/routers folder
+ * a lot in the "/src/server/api/routers" directory.
  */
 
 /**
- * This is how you create new routers and subrouters in your tRPC API
+ * This is how you create new routers and sub-routers in your tRPC API.
  * @see https://trpc.io/docs/router
  */
 export const createTRPCRouter = t.router;
 
 /**
- * Public (unauthed) procedure
+ * Public (unauthenticated) procedure
  *
  * This is the base piece you use to build new queries and mutations on your
  * tRPC API. It does not guarantee that a user querying is authorized, but you
- * can still access user session data if they are logged in
+ * can still access user session data if they are logged in.
  */
 export const publicProcedure = t.procedure;

--- a/cli/template/extras/src/server/api/trpc/with-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-prisma.ts
@@ -27,7 +27,7 @@ type CreateContextOptions = Record<string, never>;
  * it, you can export it from here
  *
  * Examples of things you may need it for:
- * - testing, so we dont have to mock Next.js' req/res
+ * - testing, so we don't have to mock Next.js' req/res
  * - trpc's `createSSGHelpers` where we don't have req/res
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */

--- a/cli/template/extras/src/server/api/trpc/with-prisma.ts
+++ b/cli/template/extras/src/server/api/trpc/with-prisma.ts
@@ -27,7 +27,8 @@ type CreateContextOptions = Record<string, never>;
  *
  * Examples of things you may need it for:
  * - testing, so we don't have to mock Next.js' req/res
- * - trpc's `createSSGHelpers`, where we don't have req/res
+ * - tRPC's `createSSGHelpers`, where we don't have req/res
+ *
  * @see https://create.t3.gg/en/usage/trpc#-servertrpccontextts
  */
 const createInnerTRPCContext = (_opts: CreateContextOptions) => {
@@ -39,6 +40,7 @@ const createInnerTRPCContext = (_opts: CreateContextOptions) => {
 /**
  * This is the actual context you will use in your router. It will be used to
  * process every request that goes through your tRPC endpoint.
+ *
  * @see https://trpc.io/docs/context
  */
 export const createTRPCContext = (_opts: CreateNextContextOptions) => {
@@ -70,6 +72,7 @@ const t = initTRPC.context<typeof createTRPCContext>().create({
 
 /**
  * This is how you create new routers and sub-routers in your tRPC API.
+ *
  * @see https://trpc.io/docs/router
  */
 export const createTRPCRouter = t.router;

--- a/cli/template/extras/src/server/auth/base.ts
+++ b/cli/template/extras/src/server/auth/base.ts
@@ -8,9 +8,10 @@ import DiscordProvider from "next-auth/providers/discord";
 import { env } from "../env/server.mjs";
 
 /**
- * Module augmentation for `next-auth` types
- * Allows us to add custom properties to the `session` object
- * and keep type safety
+ * Module augmentation for `next-auth` types.
+ * Allows us to add custom properties to the `session` object and keep type
+ * safety.
+ *
  * @see https://next-auth.js.org/getting-started/typescript#module-augmentation
  **/
 declare module "next-auth" {
@@ -29,8 +30,9 @@ declare module "next-auth" {
 }
 
 /**
- * Options for NextAuth.js used to configure
- * adapters, providers, callbacks, etc.
+ * Options for NextAuth.js used to configure adapters, providers, callbacks,
+ * etc.
+ *
  * @see https://next-auth.js.org/configuration/options
  **/
 export const authOptions: NextAuthOptions = {
@@ -55,14 +57,16 @@ export const authOptions: NextAuthOptions = {
      * For example, the GitHub provider requires you to add the
      * `refresh_token_expires_in` field to the Account model. Refer to the
      * NextAuth.js docs for the provider you want to use. Example:
+     *
      * @see https://next-auth.js.org/providers/github
      **/
   ],
 };
 
 /**
- * Wrapper for getServerSession so that you don't need
- * to import the authOptions in every file.
+ * Wrapper for `getServerSession` so that you don't need to import the
+ * `authOptions` in every file.
+ *
  * @see https://next-auth.js.org/configuration/nextjs
  **/
 export const getServerAuthSession = (ctx: {

--- a/cli/template/extras/src/server/auth/with-prisma.ts
+++ b/cli/template/extras/src/server/auth/with-prisma.ts
@@ -10,9 +10,10 @@ import { env } from "../env/server.mjs";
 import { prisma } from "./db";
 
 /**
- * Module augmentation for `next-auth` types
- * Allows us to add custom properties to the `session` object
- * and keep type safety
+ * Module augmentation for `next-auth` types.
+ * Allows us to add custom properties to the `session` object and keep type
+ * safety.
+ *
  * @see https://next-auth.js.org/getting-started/typescript#module-augmentation
  **/
 declare module "next-auth" {
@@ -31,8 +32,9 @@ declare module "next-auth" {
 }
 
 /**
- * Options for NextAuth.js used to configure
- * adapters, providers, callbacks, etc.
+ * Options for NextAuth.js used to configure adapters, providers, callbacks,
+ * etc.
+ *
  * @see https://next-auth.js.org/configuration/options
  **/
 export const authOptions: NextAuthOptions = {
@@ -64,8 +66,9 @@ export const authOptions: NextAuthOptions = {
 };
 
 /**
- * Wrapper for getServerSession so that you don't need
- * to import the authOptions in every file.
+ * Wrapper for `getServerSession` so that you don't need to import the
+ * `authOptions` in every file.
+ *
  * @see https://next-auth.js.org/configuration/nextjs
  **/
 export const getServerAuthSession = (ctx: {

--- a/cli/template/extras/src/utils/api.ts
+++ b/cli/template/extras/src/utils/api.ts
@@ -1,7 +1,7 @@
 /**
  * This is the client-side entrypoint for your tRPC API.
- * It's used to create the `api` object which contains the Next.js App-wrapper
- * as well as your typesafe react-query hooks.
+ * It is used to create the `api` object which contains the Next.js
+ * App-wrapper, as well as your type-safe React Query hooks.
  *
  * We also create a few inference helpers for input and output types
  */
@@ -18,20 +18,20 @@ const getBaseUrl = () => {
   return `http://localhost:${process.env.PORT ?? 3000}`; // dev SSR should use localhost
 };
 
-/**
- * A set of typesafe react-query hooks for your tRPC API
- */
+/** A set of type-safe react-query hooks for your tRPC API. */
 export const api = createTRPCNext<AppRouter>({
   config() {
     return {
       /**
-       * Transformer used for data de-serialization from the server
+       * Transformer used for data de-serialization from the server.
+       *
        * @see https://trpc.io/docs/data-transformers
        **/
       transformer: superjson,
 
       /**
-       * Links used to determine request flow from client to server
+       * Links used to determine request flow from client to server.
+       *
        * @see https://trpc.io/docs/links
        * */
       links: [
@@ -47,19 +47,23 @@ export const api = createTRPCNext<AppRouter>({
     };
   },
   /**
-   * Whether tRPC should await queries when server rendering pages
+   * Whether tRPC should await queries when server rendering pages.
+   *
    * @see https://trpc.io/docs/nextjs#ssr-boolean-default-false
    */
   ssr: false,
 });
 
 /**
- * Inference helper for inputs
+ * Inference helper for inputs.
+ *
  * @example type HelloInput = RouterInputs['example']['hello']
  **/
 export type RouterInputs = inferRouterInputs<AppRouter>;
+
 /**
- * Inference helper for outputs
+ * Inference helper for outputs.
+ *
  * @example type HelloOutput = RouterOutputs['example']['hello']
  **/
 export type RouterOutputs = inferRouterOutputs<AppRouter>;


### PR DESCRIPTION
- Fixes grammar issues.
- Standardize `@see` formatting. (Typically there should be a newline between a JSDoc body and any JSDoc tags.)

If you want a lint rule to verify JSDoc formatting + JSDoc complete sentences (i.e. erroneous missing periods) going forward, I've already written one.