### PR TITLE
fix(www): show `Translate this page` only on EN pages 

### DIFF
--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -54,7 +54,7 @@ const isLangEN = getLanguageFromURL(pathname) === "en";
     <li
       class={clsx(
         "hidden text-t3-purple-800 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100",
-        !isLangEN && "md:block",
+        isLangEN && "md:block",
       )}
     >
       <a


### PR DESCRIPTION


## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The translate button should be on the English pages only. Showing it on already translated pages doesn't make sense since the page is already translated. If someone wants to update the translated page they can use the `Edit this page` button. However, for starting to translate from the original EN language, the instructions on TRANSLATION.md should be followed.

I've [mentioned](https://github.com/t3-oss/create-t3-app/pull/946#discussion_r1045068987) this before but completely forgot about it till now. [Astro docs](https://docs.astro.build/en/getting-started/) also follow this rule of only showing the button on English pages.

---

## Screenshots

- Before

![image](https://user-images.githubusercontent.com/89210438/215578862-895ad6a4-3b94-4b24-a9a8-6addf64b8d12.png)

![image](https://user-images.githubusercontent.com/89210438/215578928-ee2457ed-b5dc-496b-ac36-05bac8e007ff.png)


- After

![image](https://user-images.githubusercontent.com/89210438/215578688-8af2f622-38f3-4930-96a7-94b728b9157f.png)

![image](https://user-images.githubusercontent.com/89210438/215578745-d9dd7171-7b46-4d3c-82de-47f977ef73df.png)


💯
