### PR TITLE
fix: swapped ts-check comments to checkJs in tsconfig

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -37,7 +37,7 @@ jobs:
               no: ["estubmo", "josephayman"],
               pl: ["matibox", "Infiplaya", "PiotrekPKP"],
               pt: ["claudiofreitas", "minsk-dev", "Sn0wye", "victoriaquasar"],
-              ru: ["AmadeusTwi", "ronanru", "Yevhenii-Bakhmat"],
+              ru: ["AmadeusTwi", "ronanru", "JohnBakhmat"],
               "zh-hans": ["fernandoxu", "lodisy"],
             };
 

--- a/cli/template/base/src/env/client.mjs
+++ b/cli/template/base/src/env/client.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { clientEnv, clientSchema } from "./schema.mjs";
 
 const _clientEnv = clientSchema.safeParse(clientEnv);

--- a/cli/template/base/src/env/schema.mjs
+++ b/cli/template/base/src/env/schema.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { z } from "zod";
 
 /**

--- a/cli/template/base/src/env/server.mjs
+++ b/cli/template/base/src/env/server.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 /**
  * This file is included in `/next.config.mjs` which ensures the app isn't built with invalid env vars.
  * It has to be a `.mjs`-file to be imported there.

--- a/cli/template/extras/src/env/schema/with-auth-prisma.mjs
+++ b/cli/template/extras/src/env/schema/with-auth-prisma.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { z } from "zod";
 
 /**

--- a/cli/template/extras/src/env/schema/with-auth.mjs
+++ b/cli/template/extras/src/env/schema/with-auth.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { z } from "zod";
 
 /**

--- a/cli/template/extras/src/env/schema/with-prisma.mjs
+++ b/cli/template/extras/src/env/schema/with-prisma.mjs
@@ -1,4 +1,3 @@
-// @ts-check
 import { z } from "zod";
 
 /**

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": "./",
     "paths": {
       "~/*": ["./src/*"]
-    }
+    },
+    "checkJs": true
   },
   "include": ["src", ".eslintrc.cjs"]
 }

--- a/www/src/pages/en/faq.md
+++ b/www/src/pages/en/faq.md
@@ -46,7 +46,7 @@ Now, we realize this path doesn't work for everyone. So, if you feel like you've
 
 As per [T3-Axiom #3](/en/introduction#typesafety-isnt-optional), we take typesafety as a first class citizen. Unfortunately, not all frameworks and plugins support TypeScript which means some of the configuration files have to be `.js` files.
 
-We try to emphasize that these files are JavaScript for a reason, by explicitly declaring each file's type (`cjs` or `mjs`) depending on what's supported by the library it is used by. Also, all the `js` files in this project are still typechecked using a `@ts-check` comment at the top.
+We try to emphasize that these files are JavaScript for a reason, by explicitly declaring each file's type (`cjs` or `mjs`) depending on what's supported by the library it is used by. Also, all the `js` files in this project are still typechecked using a checkJs option in the compiler (tsconfig).
 
 ## I'm struggling to add i18n to my app. Is there any reference I can use?
 


### PR DESCRIPTION
Closes #1149

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Addressing issue #1149 . Removed the @ts-check comment in js / mjs files in the cli folder in favor of the checkJs option in tsconfig.json. Better follows DRY principles and more strictly enforces typesafety.

---

💯
