### PR TITLE
fix: "create t3-app" -> "create-t3-app"

### DIFF
--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -48,7 +48,7 @@ jobs:
             A new create-t3-app prerelease is available for testing. You can install this latest build in your project with:
 
             ```sh
-            pnpm create t3-app@${{ env.BETA_PACKAGE_VERSION }}
+            pnpm create-t3-app@${{ env.BETA_PACKAGE_VERSION }}
             ```
 
       - name: "Remove the autorelease label once published"

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  Get started with the <a rel="noopener noreferrer" target="_blank" href="https://init.tips">T3 Stack</a> by running <code>npm create t3-app@latest</code>
+  Get started with the <a rel="noopener noreferrer" target="_blank" href="https://init.tips">T3 Stack</a> by running <code>npm create-t3-app@latest</code>
 </p>
 
 <div align="center">
@@ -81,19 +81,19 @@ To scaffold an app using `create-t3-app`, run any of the following three command
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 For more advanced usage, check out the [CLI docs](https://create.t3.gg/en/installation).

--- a/www/src/components/landingPage/banner.astro
+++ b/www/src/components/landingPage/banner.astro
@@ -74,7 +74,7 @@ import Button from "./button.astro";
                     title="Copy the command to get started"
                     id="command"
                   >
-                    <code id="command-text">npm create t3-app@latest</code>
+                    <code id="command-text">npm create-t3-app@latest</code>
                     <svg
                       id="copy-icon"
                       xmlns="http://www.w3.org/2000/svg"

--- a/www/src/components/landingPage/cli.tsx
+++ b/www/src/components/landingPage/cli.tsx
@@ -17,7 +17,7 @@ export default function CodeCard() {
           <div className="ml-2 h-3 w-3 rounded-full bg-green-500"></div>
         </div>
         <Typist cursor={{ hideWhenDone: true, hideWhenDoneDelay: 0 }}>
-          npm create t3-app@latest
+          npm create-t3-app@latest
           <Typist.Delay ms={1250} />
         </Typist>
         <Typist

--- a/www/src/pages/ar/installation.md
+++ b/www/src/pages/ar/installation.md
@@ -11,19 +11,19 @@ dir: rtl
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 بعد أن تَنتهي عَملية إنشاء التطبيق، اَلق نَظرة عَلي [الخطوات الأولى](/ar/usage/first-steps) للبدء في تطبيقك الجديد.

--- a/www/src/pages/en/installation.md
+++ b/www/src/pages/en/installation.md
@@ -10,19 +10,19 @@ To scaffold an app using `create-t3-app`, run any of the following three command
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 After your app has been scaffolded, check out the [first steps](/en/usage/first-steps) to get started on your new application.

--- a/www/src/pages/fr/installation.md
+++ b/www/src/pages/fr/installation.md
@@ -10,19 +10,19 @@ Pour configurer une application à l'aide de `create-t3-app`, exécutez l'une de
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 Une fois votre application configurée, consultez les [premières étapes](/fr/usage/first-steps) pour démarrer sur votre nouvelle application.

--- a/www/src/pages/no/installation.md
+++ b/www/src/pages/no/installation.md
@@ -10,19 +10,19 @@ For å lage en app med `create-t3-app`, kjør en av følgende tre kommandoer og 
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 Etter at applikasjonen din har blitt opprettet, sjekk ut [første steg](/no/usage/first-steps) for å begynne å utvikle den nye applikasjonen.

--- a/www/src/pages/pl/installation.md
+++ b/www/src/pages/pl/installation.md
@@ -10,19 +10,19 @@ Aby zacząć używać szablonu `create-t3-app`, uruchom którąkolwiek z poniżs
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 Po tym, jak szablon aplikacji zostanie utworzony, sprawdź [pierwsze kroki](/pl/usage/first-steps) aby zacząć budować swoją nową aplikację.

--- a/www/src/pages/pt/installation.md
+++ b/www/src/pages/pt/installation.md
@@ -10,19 +10,19 @@ Para estruturar uma aplicação usando `create-t3-app`, rode qualquer um dos com
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 Após sua aplicação ter sido estruturada, verifique os [Primeiros Passos](/pt/usage/first-steps) para começar a usar sua nova aplicação.

--- a/www/src/pages/ru/installation.md
+++ b/www/src/pages/ru/installation.md
@@ -10,19 +10,19 @@ lang: ru
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 После того, как приложение будет создано, ознакомьтесь с [первыми шагами](/ru/usage/first-steps), чтобы начать работу над вашим новым приложением.

--- a/www/src/pages/zh-hans/installation.md
+++ b/www/src/pages/zh-hans/installation.md
@@ -10,19 +10,19 @@ lang: zh-hans
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 在你的应用程序被创建后，请查看 [第一步](/zh-hans/usage/first-steps) 以开始你的新应用。


### PR DESCRIPTION
Yeah, the code blocks on the website were missing the dash between "create" and "t3", so when you copied the command and ran it in your CLI, nothing happened. So I just added the dashes everywhere I could find.

## ✅ Checklist

- ✅ I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- ✅ The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- ✅ I performed a functional test on my final commit

---

## Changelog

changed "create t3-app" to "create-t3-app"

---

## Screenshots

None

💯
