### PR TITLE
feat: use `class:list` instead of `clsx` in astro components

### DIFF
--- a/www/src/components/landingPage/pageSection.astro
+++ b/www/src/components/landingPage/pageSection.astro
@@ -1,6 +1,4 @@
 ---
-import clsx from "clsx";
-
 export interface Props {
   size: "6" | "12" | "16" | "24" | "32";
   className?: string;
@@ -29,7 +27,7 @@ const { size, className, bottomPadding = true, id = "" } = Astro.props;
 
 <section
   id={id}
-  class={clsx(className, bottomPadding ? sizes[size] : sizesOnlyTop[size])}
+  class:list={[className, bottomPadding ? sizes[size] : sizesOnlyTop[size]]}
 >
   <slot />
 </section>

--- a/www/src/components/landingPage/tweets/tweetSlider.astro
+++ b/www/src/components/landingPage/tweets/tweetSlider.astro
@@ -1,5 +1,4 @@
 ---
-import clsx from "clsx";
 import TweetCard from "./tweetCard.astro";
 import type { Tweet } from "./types";
 
@@ -32,12 +31,12 @@ const { tweets } = Astro.props as Props;
           data-slider-page={idx}
         >
           <div
-            class={clsx(
+            class:list={[
               "aspect-square h-2 rounded-full bg-white/20 transition-colors ease-in-out [&.active]:bg-primary [&:not(.active)]:hover:bg-white/40",
               {
                 active: idx === 0,
               },
-            )}
+            ]}
           />
         </button>
       ))

--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -1,6 +1,5 @@
 ---
 import { fetchGithub } from "../../utils/fetchGithub";
-import clsx from "clsx";
 import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
 
 type GithubRepoResponse = {
@@ -31,7 +30,7 @@ const isRtl = getIsRtlFromUrl(pathname);
 >
   <div
     id="github-star"
-    class={clsx(
+    class:list={[
       "relative ltr:mr-[.33em] rtl:ml-[.33em] hidden md:flex items-center bg-clip-padding rounded-lg no-underline border-t3-purple-200/50 group-hover:border-t3-purple-200/75 bg-t3-purple-200/50 dark:bg-t3-purple-200/10 border dark:border-t3-purple-200/20 dark:group-hover:bg-t3-purple-200/10 group-hover:bg-t3-purple-200/75 dark:group-hover:border-t3-purple-200/50 transition-colors duration-300 py-1 px-2 text-slate-800 dark:text-slate-100",
       [
         /** triangle arrow */
@@ -41,7 +40,7 @@ const isRtl = getIsRtlFromUrl(pathname);
         !isRtl &&
           "after:right-[calc(-0.5em-1px)] after:border-r-0 after:border-l-t3-purple-200/50 after:group-hover:border-l-t3-purple-200/75 dark:after:border-l-t3-purple-200/20 dark:after:group-hover:border-l-t3-purple-200/50",
       ],
-    )}
+    ]}
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/www/src/components/navigation/leftSidebar.astro
+++ b/www/src/components/navigation/leftSidebar.astro
@@ -1,5 +1,4 @@
 ---
-import clsx from "clsx";
 import { getIsRtlFromUrl } from "../../languages";
 import { Frontmatter, SIDEBAR, SIDEBAR_HEADER_MAP } from "../../config";
 import Search from "./Search";
@@ -71,13 +70,13 @@ if (langCode !== "en") {
         <li>
           <div>
             <h2
-              class={clsx(
+              class:list={[
                 "pb-2 text-xl font-semibold transition-colors duration-300 sm:text-lg",
                 {
                   // mobile menu on landing page
                   "text-slate-50": isLanding,
                 },
-              )}
+              ]}
             >
               {header}
             </h2>
@@ -90,13 +89,13 @@ if (langCode !== "en") {
                     <a
                       href={url}
                       aria-current={isActive ? "page" : false}
-                      class={clsx([
+                      class:list={[
                         "text-md block py-2 text-t3-purple-800 transition-colors [padding-inline-start:16px] hover:border-t3-purple-300/50 hover:bg-t3-purple-300/20 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:bg-t3-purple-300/10 dark:hover:text-t3-purple-100",
                         isActive
                           ? "border-t3-purple-300 bg-t3-purple-300/30 font-medium dark:bg-t3-purple-300/20"
                           : "border-t3-purple-300/20",
                         isRtl ? "border-r-2" : "border-l-2",
-                      ])}
+                      ]}
                     >
                       <span>{child.text}</span>
                       {!child.isTranslated && langCode !== "en" && (

--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -1,7 +1,6 @@
 ---
 import * as CONFIG from "../../config";
 import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
-import clsx from "clsx";
 
 export interface Props {
   editHref: string;
@@ -52,10 +51,10 @@ const isLangEN = getLanguageFromURL(pathname) === "en";
     </li>
 
     <li
-      class={clsx(
+      class:list={[
         "hidden text-t3-purple-800 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100",
         isLangEN && "md:block",
-      )}
+      ]}
     >
       <a
         class="flex items-center gap-2"

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -105,9 +105,3 @@ const navbarLinks: Array<{ href: string; label: string }> = [
     </div>
   </div>
 </nav>
-
-<style>
-  .test {
-    color: red;
-  }
-</style>

--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -1,5 +1,4 @@
 ---
-import clsx from "clsx";
 import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
 import GithubIcon from "./githubIcon.astro";
 import Search from "./Search";
@@ -32,13 +31,13 @@ const navbarLinks: Array<{ href: string; label: string }> = [
 ---
 
 <nav
-  class={clsx(
+  class:list={[
     "navbar flex flex-col relative justify-between items-center py-4",
     {
       "z-40 text-slate-50": isLanding,
       "transition-colors duration-300": !isLanding,
     },
-  )}
+  ]}
   aria-label="Global"
 >
   <div class="flex w-full max-w-7xl items-center justify-between px-4">
@@ -55,16 +54,16 @@ const navbarLinks: Array<{ href: string; label: string }> = [
         </a>
       </div>
       <div
-        class={clsx([
+        class:list={[
           "hidden -space-x-1 md:flex gap-2",
           isLtr && "md:ml-10",
           isRtl && "md:mr-10",
-        ])}
+        ]}
       >
         {
           navbarLinks.map((navbarLink) => (
             <a
-              class={clsx(
+              class:list={[
                 "relative inline-flex items-center rounded-md border border-transparent px-3 py-2 transition-colors hover:no-underline",
                 {
                   "border bg-t3-purple-200/50 text-t3-purple-800 dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50":
@@ -74,7 +73,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
                   "rounded-lg text-t3-purple-800 hover:bg-t3-purple-200/50 hover:text-t3-purple-800 dark:text-t3-purple-100 dark:hover:bg-t3-purple-200/10 dark:hover:text-t3-purple-300":
                     !isLanding,
                 },
-              )}
+              ]}
               aria-current={navbarLink.href === currentPage ? "page" : "false"}
               href={navbarLink.href}
             >
@@ -88,9 +87,12 @@ const navbarLinks: Array<{ href: string; label: string }> = [
       <GithubIcon />
       {!isLanding && <LanguageSelect language={langCode} client:load />}
       <div
-        class={clsx("text-center", {
-          hidden: isLanding,
-        })}
+        class:list={[
+          "text-center",
+          {
+            hidden: isLanding,
+          },
+        ]}
       >
         <ThemeToggleButton />
       </div>
@@ -103,3 +105,9 @@ const navbarLinks: Array<{ href: string; label: string }> = [
     </div>
   </div>
 </nav>
+
+<style>
+  .test {
+    color: red;
+  }
+</style>

--- a/www/src/components/navigation/sidebarToggle.astro
+++ b/www/src/components/navigation/sidebarToggle.astro
@@ -1,6 +1,4 @@
 ---
-import clsx from "clsx";
-
 export interface Props {
   isLanding: boolean;
 }
@@ -12,10 +10,13 @@ const { isLanding } = Astro.props;
   id="sidebar-toggle"
   type="button"
   aria-pressed="false"
-  class={clsx("z-20 block md:hidden", {
-    "text-white": isLanding,
-    "text-black dark:text-white": !isLanding,
-  })}
+  class:list={[
+    "z-20 block md:hidden",
+    {
+      "text-white": isLanding,
+      "text-black dark:text-white": !isLanding,
+    },
+  ]}
 >
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/www/src/components/navigation/tableOfContents.astro
+++ b/www/src/components/navigation/tableOfContents.astro
@@ -1,6 +1,5 @@
 ---
 import type { MarkdownHeading } from "astro";
-import clsx from "clsx";
 import { getIsRtlFromUrl } from "../../languages";
 
 export interface Props {
@@ -53,12 +52,12 @@ const isRtl = getIsRtlFromUrl(pathname);
         return (
           <li
             data-components={dataComponentType || null}
-            class={clsx(
+            class:list={[
               "w-full list-none border-t3-purple-300/20 p-1 text-sm transition-colors duration-300 hover:border-t3-purple-300/50",
               isRtl
                 ? ["border-r-2", depth === 2 ? "pr-2" : "pr-4"]
                 : ["border-l-2", depth === 2 ? "pl-2" : "pl-4"],
-            )}
+            ]}
           >
             <a
               class="text-t3-purple-800 hover:text-t3-purple-400 dark:text-t3-purple-200 dark:hover:text-t3-purple-100"


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Use astro's built-in `class:list` instead of `clsx` in astro components. React components still use `clsx`.

---

## Screenshots

_[Screenshots]_

💯
