### PR TITLE
chore: housekeeping in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ yarn-error.log*
 
 # MISC
 .idea
-.turbo/
 .cache/
 .next/
 .nuxt/


### PR DESCRIPTION
This commit removes a duplicate gitignore declaration.  `.turbo` is declared and grouped ideologically with .vercel on line 48.

This change has no functional effect on stability.  It is just a maintenance contribution.

## Alternatives
An alternative to this fix would be to move .vercel into the MISC subset and remove line 48, whichever would be maintainers' preference.