### PR TITLE
fix: wrong link

### DIFF
--- a/www/TRANSLATIONS.md
+++ b/www/TRANSLATIONS.md
@@ -36,4 +36,4 @@ Naturally, the English docs will move faster than the translated ones. We've imp
 
 We also have code owners for each language. Being a code owner means that you get notified when there is a PR that includes changes to the files of your language, so that you can review it.
 
-Becoming a code owner is open to anyone who has contributed to a language, either by writing translations themselves or by reviewing those of others. If would like to become a code owner, either add your GitHub username to your language in [translations.yml](https://github.com/t3-oss/create-t3-app/blob/next/.github/workflows/translations.yml) or let us know in the `create-t3-translation` channel on [Discord](https://create.t3.gg/discord).
+Becoming a code owner is open to anyone who has contributed to a language, either by writing translations themselves or by reviewing those of others. If would like to become a code owner, either add your GitHub username to your language in [translations.yml](https://github.com/t3-oss/create-t3-app/blob/next/.github/workflows/translations.yml) or let us know in the `create-t3-translation` channel on [Discord](https://t3.gg/discord).

--- a/www/TRANSLATIONS.md
+++ b/www/TRANSLATIONS.md
@@ -36,4 +36,4 @@ Naturally, the English docs will move faster than the translated ones. We've imp
 
 We also have code owners for each language. Being a code owner means that you get notified when there is a PR that includes changes to the files of your language, so that you can review it.
 
-Becoming a code owner is open to anyone who has contributed to a language, either by writing translations themselves or by reviewing those of others. If would like to become a code owner, either add your GitHub username to your language in [translations.yml](https://github.com/t3-oss/create-t3-app/blob/next/.github/workflows/translations.yml) or let us know in the `create-t3-translation` channel on [Discord](https://t3.gg/discord).
+Becoming a code owner is open to anyone who has contributed to a language, either by writing translations themselves or by reviewing those of others. If would like to become a code owner, either add your GitHub username to your language in [translations.yml](https://github.com/t3-oss/create-t3-app/blob/next/.github/workflows/translations.yml) or let us know in the `create-t3-translation` channel on [Discord](https://create.t3.gg/discord).

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -22,7 +22,7 @@
     },
     {
       "source": "/discord",
-      "destination": "https://discord.gg/t3dotgg"
+      "destination": "https://discord.gg/xHdCpcPHRE"
     },
     {
       "source": "/github",


### PR DESCRIPTION
The link to the discord channel was redirecting to the wrong URL.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)

---

## Changelog

I changed the discord link on https://github.com/t3-oss/create-t3-app/edit/next/www/TRANSLATIONS.md to the correct one.

---