### PR TITLE
fix: ensure .eslint.cjs is included in git

### DIFF
--- a/.changeset/poor-grapes-think.md
+++ b/.changeset/poor-grapes-think.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Rename \_eslint.cjs before intializing git repo to ensure .eslint.cjs is added by default

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -67,15 +67,15 @@ const main = async () => {
     await installDependencies({ projectDir });
   }
 
-  if (!noGit) {
-    await initializeGit(projectDir);
-  }
-
   // Rename _eslintrc.json to .eslintrc.json - we use _eslintrc.json to avoid conflicts with the monorepos linter
   fs.renameSync(
     path.join(projectDir, "_eslintrc.cjs"),
     path.join(projectDir, ".eslintrc.cjs"),
   );
+
+  if (!noGit) {
+    await initializeGit(projectDir);
+  }
 
   logNextSteps({ projectName: appDir, packages: usePackages, noInstall });
 


### PR DESCRIPTION
Closes #1251

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Moved the renaming of the `_eslint.cjs` file to before the git initialization to ensure the file is included by default.

---

## Screenshots
Repo with what will be output and included in git by default. 
Options: Typescript, no packages, yes initialize git, yes npm install, default import alias.
ran `git commit` without any other changes made

https://github.com/ggrochow/create-t3-example

💯
