### PR TITLE
chore: Remove gitignored next-env.d.ts

### DIFF
--- a/.changeset/famous-geese-chew.md
+++ b/.changeset/famous-geese-chew.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Remove gitignored next-env.d.ts

--- a/cli/template/base/next-env.d.ts
+++ b/cli/template/base/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Remove gitignored next-env.d.ts per https://nextjs.org/docs/basic-features/typescript:

> A file named next-env.d.ts will be created at the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. You should not remove it or edit it as it can change at any time. This file should not be committed and should be ignored by version control (e.g. inside your .gitignore file).
