### PR TITLE
fix: search for tsconfig relative to eslintrc

### DIFF
--- a/.changeset/fresh-cars-tease.md
+++ b/.changeset/fresh-cars-tease.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+search for tsconfig relative to eslintrc

--- a/cli/template/base/_eslintrc.cjs
+++ b/cli/template/base/_eslintrc.cjs
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const path = require("path");
+
 /** @type {import("eslint").Linter.Config} */
 const config = {
   overrides: [
@@ -7,13 +10,13 @@ const config = {
       ],
       files: ["*.ts", "*.tsx"],
       parserOptions: {
-        project: "tsconfig.json",
+        project: path.join(__dirname, "tsconfig.json"),
       },
     },
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: "./tsconfig.json",
+    project: path.join(__dirname, "tsconfig.json"),
   },
   plugins: ["@typescript-eslint"],
   extends: ["next/core-web-vitals", "plugin:@typescript-eslint/recommended"],


### PR DESCRIPTION
## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

I created a t3-app in an existing monorepo and I expect eslint to use the config file that is in the project and not in the turborepo root. The current `.eslintrc.cjs` always searches for the `tsconfig.json` in the root of the project. I resolved the path to do a relative seach, which is what most people expect if there lies a `tsconfig.json` next to the `eslintrc.cjs`.

💯
