### PR TITLE
feat: ignore vars that start with `_` for eslint no-unused-vars ignore

### DIFF
--- a/.changeset/nice-bugs-tickle.md
+++ b/.changeset/nice-bugs-tickle.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+ignore unused vars that begin with underscore

--- a/cli/template/base/_eslintrc.cjs
+++ b/cli/template/base/_eslintrc.cjs
@@ -25,6 +25,7 @@ const config = {
         fixStyle: "inline-type-imports",
       },
     ],
+    "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
   },
 };
 


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Reason for this change is that currently templates that don't do anything with args in createContext (ie any without next-auth) throw an eslint warning. Also using `_` as "i'm not using this" is a common enough pattern that I think it's worth allowing by default.

see: https://discord.com/channels/966627436387266600/1081204127327059998

💯
