### PR TITLE
fix: Detects terminal instead of shell for interactivity #1281

### DIFF
--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -157,10 +157,7 @@ export const runCli = async () => {
 
   // Explained below why this is in a try/catch block
   try {
-    if (
-      process.env.SHELL?.toLowerCase().includes("git") &&
-      process.env.SHELL?.includes("bash")
-    ) {
+    if (process.env.SHELL?.includes("mintty")) {
       logger.warn(`  WARNING: It looks like you are using Git Bash which is non-interactive. Please run create-t3-app with another
   terminal such as Windows Terminal or PowerShell if you want to use the interactive CLI.`);
 


### PR DESCRIPTION
Closes #1281 

## ✅ Checklist

- [✅ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [✅ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ✅] I performed a functional test on my final commit

---

## Changelog

_Changed the check of interactivity from git-bash to mintty since using git-bash on windows terminal is interactive._

---

💯
