### PR TITLE
docs: update tweets copy, remove for now

### DIFF
--- a/www/src/components/landingPage/tweets/tweets.astro
+++ b/www/src/components/landingPage/tweets/tweets.astro
@@ -20,7 +20,7 @@ import { featuredTweets } from "./featuredTweets";
     <h3
       class="mt-2 text-3xl font-bold tracking-tight text-t3-purple-50 md:text-5xl lg:text-5xl"
     >
-      Our users <span class="italic">make ship happen</span>
+      Our users ship. <span class="italic">Fast.</span>
     </h3>
     <p
       class="mt-4 max-w-3xl text-base text-t3-purple-200 md:text-lg lg:text-lg"

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -3,7 +3,6 @@ import LandingPage from "../layouts/landingPage.astro";
 import Banner from "../components/landingPage/banner.astro";
 import About from "../components/landingPage/about.astro";
 import Features from "../components/landingPage/stack/stack.astro";
-import Tweets from "../components/landingPage/tweets/tweets.astro";
 import Community from "../components/landingPage/community/community.astro";
 ---
 
@@ -11,6 +10,5 @@ import Community from "../components/landingPage/community/community.astro";
   <Banner />
   <About />
   <Features />
-  <Tweets />
   <Community />
 </LandingPage>


### PR DESCRIPTION
Turns out I unintentionally borrowed copy from Turbo, so I updated that. Also saw the embedded tweets were super out of date so I removed the widget for now