### PR TITLE
fix: add indications for Type Error caused by id property on user object

### DIFF
--- a/.changeset/silver-ears-double.md
+++ b/.changeset/silver-ears-double.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fix type error when using google oauth provider due to id property not existing

--- a/cli/template/extras/src/server/auth/base.ts
+++ b/cli/template/extras/src/server/auth/base.ts
@@ -37,7 +37,10 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     session({ session, user }) {
       if (session.user) {
-        session.user.id = user.id;
+        // Check the shape of the data returned by the providers you use
+        // before adding other properties on the session.
+        // For example Google OAuth provider does not return an id for the user.
+        // session.user.id = user.id;
         // session.user.role = user.role; <-- put other properties on the session here
       }
       return session;

--- a/cli/template/extras/src/server/auth/base.ts
+++ b/cli/template/extras/src/server/auth/base.ts
@@ -40,7 +40,7 @@ export const authOptions: NextAuthOptions = {
         // Check the shape of the data returned by the providers you use
         // before adding other properties on the session.
         // For example Google OAuth provider does not return an id for the user.
-        // session.user.id = user.id;
+        session.user.id = user.id;
         // session.user.role = user.role; <-- put other properties on the session here
       }
       return session;


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Add comment to indicate that the user should check the shape of the returned object when authenticating with NextAuth providers.
For example the Google OAuth provider does not return an `id` property on the user object causing this line of code `session.user.id = user.id`  to throw a Type Error.

---

## Screenshots

_[Screenshots]_

💯
