### PR TITLE
fix: temporarily pin next-auth version

### DIFF
--- a/.changeset/gold-toes-compete.md
+++ b/.changeset/gold-toes-compete.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+temporarily pin next-auth version

--- a/cli/src/installers/dependencyVersionMap.ts
+++ b/cli/src/installers/dependencyVersionMap.ts
@@ -4,7 +4,7 @@
  */
 export const dependencyVersionMap = {
   // NextAuth.js
-  "next-auth": "^4.20.1",
+  "next-auth": "4.20.1", // TODO: undo after https://github.com/nextauthjs/next-auth/issues/7132 is fixed
   "@next-auth/prisma-adapter": "^1.0.5",
 
   // Prisma


### PR DESCRIPTION
Closes https://github.com/t3-oss/create-t3-app/issues/1328

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

- pins next-auth to 4.20.1
- ive also subscribed to https://github.com/nextauthjs/next-auth/issues/7132 so we can hopefully undo this asap

---

## Screenshots

_[Screenshots]_

💯
