### PR TITLE
fix: incorrect behavior of SKIP_ENV_VALIDATION

### DIFF
--- a/.changeset/blue-walls-admire.md
+++ b/.changeset/blue-walls-admire.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: incorrect behavior of SKIP_ENV_VALIDATION

--- a/cli/template/base/next.config.mjs
+++ b/cli/template/base/next.config.mjs
@@ -2,7 +2,7 @@
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.
  * This is especially useful for Docker builds.
  */
-!process.env.SKIP_ENV_VALIDATION && (await import("./src/env.mjs"));
+process.env.SKIP_ENV_VALIDATION !== "true" && (await import("./src/env.mjs"));
 
 /** @type {import("next").NextConfig} */
 const config = {

--- a/cli/template/base/src/env.mjs
+++ b/cli/template/base/src/env.mjs
@@ -38,7 +38,7 @@ const merged = server.merge(client);
 
 let env = /** @type {MergedOutput} */ (process.env);
 
-if (!!process.env.SKIP_ENV_VALIDATION == false) {
+if (process.env.SKIP_ENV_VALIDATION !== "true") {
   const isServer = typeof window === "undefined";
 
   const parsed = /** @type {MergedSafeParseReturn} */ (

--- a/cli/template/extras/src/env/with-auth-prisma.mjs
+++ b/cli/template/extras/src/env/with-auth-prisma.mjs
@@ -58,7 +58,7 @@ const merged = server.merge(client);
 
 let env = /** @type {MergedOutput} */ (process.env);
 
-if (!!process.env.SKIP_ENV_VALIDATION == false) {
+if (process.env.SKIP_ENV_VALIDATION !== "true") {
   const isServer = typeof window === "undefined";
 
   const parsed = /** @type {MergedSafeParseReturn} */ (

--- a/cli/template/extras/src/env/with-auth.mjs
+++ b/cli/template/extras/src/env/with-auth.mjs
@@ -56,7 +56,7 @@ const merged = server.merge(client);
 
 let env = /** @type {MergedOutput} */ (process.env);
 
-if (!!process.env.SKIP_ENV_VALIDATION == false) {
+if (process.env.SKIP_ENV_VALIDATION !== "true") {
   const isServer = typeof window === "undefined";
 
   const parsed = /** @type {MergedSafeParseReturn} */ (

--- a/cli/template/extras/src/env/with-prisma.mjs
+++ b/cli/template/extras/src/env/with-prisma.mjs
@@ -40,7 +40,7 @@ const merged = server.merge(client);
 
 let env = /** @type {MergedOutput} */ (process.env);
 
-if (!!process.env.SKIP_ENV_VALIDATION == false) {
+if (process.env.SKIP_ENV_VALIDATION !== "true") {
   const isServer = typeof window === "undefined";
 
   const parsed = /** @type {MergedSafeParseReturn} */ (


### PR DESCRIPTION
The current logic for checking SKIP_ENV_VALIDATION will pass if SKIP_ENV_VALIDATION is assigned to any value other than an empty string (even `false`). Ideally, SKIP_ENV_VALIDATION should only pass when its assigned value is `true` and nothing else.

Closes #

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

fix the logic for determining whether it should validate environment variables or not

---

## Screenshots

_[Screenshots]_

💯
