### PR TITLE
feat: Enforce `NEXT_PUBLIC_` env key on client with TS

### DIFF
--- a/.changeset/purple-frogs-stare.md
+++ b/.changeset/purple-frogs-stare.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Enforce `NEXT_PUBLIC_` env key on client

--- a/cli/template/base/src/env.mjs
+++ b/cli/template/base/src/env.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { z } from "zod";
 
 /**
@@ -12,9 +14,13 @@ const server = z.object({
  * Specify your client-side environment variables schema here. This way you can ensure the app isn't
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
-const client = z.object({
-  // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
-});
+const client = z.object(
+  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ (
+    {
+      // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+    }
+  ),
+);
 
 /**
  * You can't destruct `process.env` as a regular object in the Next.js edge runtimes (e.g.

--- a/cli/template/base/src/env.mjs
+++ b/cli/template/base/src/env.mjs
@@ -13,9 +13,11 @@ const server = z.object({
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
 const client = z.object(
-  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ ({
-    NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
-  }),
+  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ (
+    {
+      // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+    }
+  ),
 );
 
 /**

--- a/cli/template/base/src/env.mjs
+++ b/cli/template/base/src/env.mjs
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { z } from "zod";
 
 /**
@@ -15,11 +13,9 @@ const server = z.object({
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
 const client = z.object(
-  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ (
-    {
-      // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
-    }
-  ),
+  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ ({
+    NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+  }),
 );
 
 /**

--- a/cli/template/extras/src/env/with-auth-prisma.mjs
+++ b/cli/template/extras/src/env/with-auth-prisma.mjs
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { z } from "zod";
 
 /**

--- a/cli/template/extras/src/env/with-auth-prisma.mjs
+++ b/cli/template/extras/src/env/with-auth-prisma.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { z } from "zod";
 
 /**
@@ -27,9 +29,13 @@ const server = z.object({
  * Specify your client-side environment variables schema here. This way you can ensure the app isn't
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
-const client = z.object({
-  // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
-});
+const client = z.object(
+  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ (
+    {
+      // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+    }
+  ),
+);
 
 /**
  * You can't destruct `process.env` as a regular object in the Next.js edge runtimes (e.g.

--- a/cli/template/extras/src/env/with-auth.mjs
+++ b/cli/template/extras/src/env/with-auth.mjs
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { z } from "zod";
 
 /**

--- a/cli/template/extras/src/env/with-auth.mjs
+++ b/cli/template/extras/src/env/with-auth.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { z } from "zod";
 
 /**
@@ -26,9 +28,13 @@ const server = z.object({
  * Specify your client-side environment variables schema here. This way you can ensure the app isn't
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
-const client = z.object({
-  // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
-});
+const client = z.object(
+  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ (
+    {
+      // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+    }
+  ),
+);
 
 /**
  * You can't destruct `process.env` as a regular object in the Next.js edge runtimes (e.g.

--- a/cli/template/extras/src/env/with-prisma.mjs
+++ b/cli/template/extras/src/env/with-prisma.mjs
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { z } from "zod";
 
 /**
@@ -13,9 +15,13 @@ const server = z.object({
  * Specify your client-side environment variables schema here. This way you can ensure the app isn't
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
-const client = z.object({
-  // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
-});
+const client = z.object(
+  /** @satisfies {Record<`NEXT_PUBLIC_${string}`, import('zod').ZodType>} */ (
+    {
+      // NEXT_PUBLIC_CLIENTVAR: z.string().min(1),
+    }
+  ),
+);
 
 /**
  * You can't destruct `process.env` as a regular object in the Next.js edge runtimes (e.g.

--- a/cli/template/extras/src/env/with-prisma.mjs
+++ b/cli/template/extras/src/env/with-prisma.mjs
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { z } from "zod";
 
 /**


### PR DESCRIPTION
Closes #1369

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Enforce `NEXT_PUBLIC_` env key on client, using other non-`NEXT_PUBLIC_` key on client will give you a type error.

---

## Screenshots

![image](https://user-images.githubusercontent.com/15154097/233412091-fd37de26-ef4c-43f1-943b-b88ea1963ce9.png)

💯
