### PR TITLE
fix: clarify comments regarding prisma use of postgresql

### DIFF
--- a/cli/template/extras/prisma/schema/with-auth.prisma
+++ b/cli/template/extras/prisma/schema/with-auth.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
     provider = "sqlite"
-    // NOTE: When using postgresql, mysql or sqlserver, uncomment the @db.Text annotations in model Account below
+    // NOTE: When using mysql or sqlserver, uncomment the @db.Text annotations in model Account below
     // Further reading:
     // https://next-auth.js.org/adapters/prisma#create-the-prisma-schema
     // https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string


### PR DESCRIPTION
Reading https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#string string seems to map to Text already in postgresql, so I think this part of the comment can be removed.

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Remove mention of postgresql's need for `@db.Text`  in the Prisma schema
