### PR TITLE
fix: temporarily pin `next` version to fix vercel build error

### DIFF
--- a/.changeset/pink-tigers-smoke.md
+++ b/.changeset/pink-tigers-smoke.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+temporarily pin next to fix vercel build error

--- a/cli/template/base/package.json
+++ b/cli/template/base/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.2.1",
-    "next": "13.2.4",
+    "next": "13.3.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "zod": "^3.21.4"

--- a/cli/template/base/package.json
+++ b/cli/template/base/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.2.1",
-    "next": "^13.2.4",
+    "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "zod": "^3.21.4"


### PR DESCRIPTION
see: 
- https://github.com/t3-oss/create-t3-app/issues/1399
- https://github.com/trpc/trpc/issues/4316

let's not count it as "resolved" until builds work on latest `next` version

💯
