### PR TITLE
fix: gap between navigation and on this page header on mobile view

### DIFF
--- a/www/src/components/navigation/OnThisPageLinks.tsx
+++ b/www/src/components/navigation/OnThisPageLinks.tsx
@@ -75,7 +75,7 @@ export default function OnThisPageLinks({
   }, [headings, title]);
 
   return (
-    <div className="sticky inset-x-0 top-20 z-[11] block w-full bg-default px-4 pb-4 pt-2 lg:hidden">
+    <div className="sticky inset-x-0 top-[72px] z-[11] block w-full bg-default px-4 pb-4 pt-2 lg:hidden">
       <Menu>
         {({ open }) => (
           <div className="relative w-full">


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

- Fix small gap between main page header and on this page header links after 1023px media query break

---

## Screenshots

Before fix:

![beforeNavigationFixT3](https://user-images.githubusercontent.com/46052374/236453298-1cf0393b-8292-48e0-8fd1-85c7b5f89118.PNG)

After fix:

![afterNavigationFixT3](https://user-images.githubusercontent.com/46052374/236453327-cea63d88-06a2-4622-9a3b-7a29fa98b965.PNG)

💯
