### PR TITLE
fix: unpin next

### DIFF
--- a/.changeset/cold-fans-build.md
+++ b/.changeset/cold-fans-build.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+unpin next

--- a/cli/template/base/package.json
+++ b/cli/template/base/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "^0.2.1",
-    "next": "13.3.4",
+    "next": "^13.4.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "zod": "^3.21.4"


### PR DESCRIPTION
Closes #1399

the upstream issue was fixed in https://github.com/vercel/next.js/pull/49274 which is included in 13.4.1

💯
