### PR TITLE
fix: use token.sub instead of user.id when using auth and not prisma

### DIFF
--- a/.changeset/happy-squids-taste.md
+++ b/.changeset/happy-squids-taste.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+When using NextAuth but not Prisma, the session user's id is now set to `token.sub` instead of `user.id` because `user` is undefined when not using database sessions.

--- a/cli/template/extras/src/server/auth/base.ts
+++ b/cli/template/extras/src/server/auth/base.ts
@@ -35,11 +35,11 @@ declare module "next-auth" {
  */
 export const authOptions: NextAuthOptions = {
   callbacks: {
-    session: ({ session, user }) => ({
+    session: ({ session, token }) => ({
       ...session,
       user: {
         ...session.user,
-        id: user.id,
+        id: token.sub,
       },
     }),
   },


### PR DESCRIPTION
Closes #1388 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

When using NextAuth but not Prisma, the session user's id is now set to `token.sub` instead of `user.id` because `user` is undefined when not using database sessions.

```typescript
  callbacks: {
    session: ({ session, token }) => ({
      ...session,
      user: {
        ...session.user,
        id: token.sub,
      },
    }),
  },
```

## Screenshots

_[Screenshots]_

💯
