### PR TITLE
docs: Focus styling on GitHub contributors

### DIFF
--- a/www/src/components/docs/avatarList.astro
+++ b/www/src/components/docs/avatarList.astro
@@ -48,7 +48,7 @@ const additionalContributors = unique.length - recentContributors.length; // lis
         <li>
           <a class="rounded-full" href={`https://github.com/${item.login}`}>
             <img
-              class="h-8 w-8 sm:h-10 sm:w-10"
+              class="h-8 w-8 rounded-full sm:h-10 sm:w-10"
               alt={`Contributor ${item.login}`}
               title={`Contributor
           ${item.login}`}

--- a/www/src/components/docs/avatarList.astro
+++ b/www/src/components/docs/avatarList.astro
@@ -46,9 +46,9 @@ const additionalContributors = unique.length - recentContributors.length; // lis
     {
       recentContributors.map((item) => (
         <li>
-          <a href={`https://github.com/${item.login}`}>
+          <a class="rounded-full" href={`https://github.com/${item.login}`}>
             <img
-              class="h-8 w-8 rounded-full sm:h-10 sm:w-10"
+              class="h-8 w-8 sm:h-10 sm:w-10"
               alt={`Contributor ${item.login}`}
               title={`Contributor
           ${item.login}`}

--- a/www/src/styles/accessibility.css
+++ b/www/src/styles/accessibility.css
@@ -13,3 +13,7 @@
 *:not(:active):focus-visible {
   @apply outline-offset-4;
 }
+
+a:has(> img) {
+  @apply inline-block;
+}


### PR DESCRIPTION
Closes partially  #881

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Add outline focus outline on github contributors

---

## Screenshots

<img width="1424" alt="Screenshot 2023-05-21 at 11 37 52 PM" src="https://github.com/t3-oss/create-t3-app/assets/59978150/f09377dc-65f4-48d4-a8de-a22a24465aae">

🚀
