### PR TITLE
fix(www): remove extra line space in Tech Stack Cards of Landing Page

### DIFF
--- a/www/src/components/landingPage/stack/card.astro
+++ b/www/src/components/landingPage/stack/card.astro
@@ -25,7 +25,7 @@ const { title, href } = Astro.props;
     </p>
   </div>
   <div
-    class="h-full m-6 text-sm text-t3-purple-100 subpixel-antialiased md:text-base"
+    class="m-6 h-full text-sm text-t3-purple-100 subpixel-antialiased md:text-base"
   >
     <slot name="description" />
   </div>

--- a/www/src/components/landingPage/stack/card.astro
+++ b/www/src/components/landingPage/stack/card.astro
@@ -24,7 +24,9 @@ const { title, href } = Astro.props;
       </a>
     </p>
   </div>
-  <div class="m-6 text-sm text-t3-purple-100 subpixel-antialiased md:text-base">
+  <div
+    class="h-full m-6 text-sm text-t3-purple-100 subpixel-antialiased md:text-base"
+  >
     <slot name="description" />
   </div>
 </div>


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

- Remove extra blank line space in Next.js & tRPC cards

---

## Screenshots

- Current

![image](https://github.com/t3-oss/create-t3-app/assets/89210438/20b9e754-4577-4693-b47f-f65a20b6d732)

- After

![image](https://github.com/t3-oss/create-t3-app/assets/89210438/947dab9f-1480-4b9a-90dc-39e400c0807d)

- For reference, this is how it looked like before [PR1243](https://create-t3-app-git-fork-albbus-stack-patch-1-t3-oss.vercel.app/) was merged

![image](https://github.com/t3-oss/create-t3-app/assets/89210438/f3a9599d-df89-4b1c-9ea2-ff085323319e)


💯
