### PR TITLE
fix: incorrect language code for japanese translators github action

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -38,7 +38,7 @@ jobs:
             const CODEOWNERS = {
               ar: ["a4addel", "Sboonny"],
               fr: ["Defranos", "joachimjusth", "vdeva"],
-              jp: ["t6adev", "uehaj"],
+              ja: ["t6adev", "uehaj"],
               no: ["estubmo", "josephayman"],
               pl: ["matibox", "Infiplaya", "PiotrekPKP"],
               pt: ["minsk-dev", "Sn0wye", "victoriaquasar", "MattFerreira18", "gilhrpenner"],


### PR DESCRIPTION
was causing japanese translation maintainers to not get pinged, see: https://github.com/t3-oss/create-t3-app/pull/1458#issuecomment-1570361842

💯
