### PR TITLE
feat: remove possible trailing slash from appName prompt

### DIFF
--- a/.changeset/perfect-geckos-behave.md
+++ b/.changeset/perfect-geckos-behave.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Ignore trailing slashes when prompting the app name.

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -231,11 +231,6 @@ const promptAppName = async (): Promise<string> => {
     },
   });
 
-  // Remove potential trailing slash
-  if (appName.endsWith("/")) {
-    return appName.slice(0, -1);
-  }
-
   return appName;
 };
 

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -231,6 +231,11 @@ const promptAppName = async (): Promise<string> => {
     },
   });
 
+  // Remove potential trailing slash
+  if (appName.endsWith("/")) {
+    return appName.slice(0, -1);
+  }
+
   return appName;
 };
 

--- a/cli/src/utils/parseNameAndPath.ts
+++ b/cli/src/utils/parseNameAndPath.ts
@@ -1,3 +1,4 @@
+import { removeTrailingSlash } from "./removeTrailingSlash.js";
 import pathModule from "path";
 
 /**
@@ -15,11 +16,8 @@ import pathModule from "path";
  * - dir/@mono/app => ["@mono/app", "dir/app"]
  * - dir/app => ["app", "dir/app"]
  */
-export const parseNameAndPath = (input: string) => {
-  // Remove potential trailing slash
-  if (input.endsWith("/")) {
-    input = input.slice(0, -1);
-  }
+export const parseNameAndPath = (rawInput: string) => {
+  const input = removeTrailingSlash(rawInput);
 
   const paths = input.split("/");
 

--- a/cli/src/utils/parseNameAndPath.ts
+++ b/cli/src/utils/parseNameAndPath.ts
@@ -16,6 +16,11 @@ import pathModule from "path";
  * - dir/app => ["app", "dir/app"]
  */
 export const parseNameAndPath = (input: string) => {
+  // Remove potential trailing slash
+  if (input.endsWith("/")) {
+    input = input.slice(0, -1);
+  }
+
   const paths = input.split("/");
 
   let appName = paths[paths.length - 1];

--- a/cli/src/utils/removeTrailingSlash.ts
+++ b/cli/src/utils/removeTrailingSlash.ts
@@ -1,0 +1,7 @@
+export const removeTrailingSlash = (input: string) => {
+  if (input.length > 1 && input.endsWith("/")) {
+    input = input.slice(0, -1);
+  }
+
+  return input;
+};

--- a/cli/src/utils/validateAppName.ts
+++ b/cli/src/utils/validateAppName.ts
@@ -1,13 +1,11 @@
+import { removeTrailingSlash } from "./removeTrailingSlash.js";
+
 const validationRegExp =
   /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 
 //Validate a string against allowed package.json names
-export const validateAppName = (input: string) => {
-  // Ignore potential trailing slash
-  if (input.endsWith("/")) {
-    input = input.slice(0, -1);
-  }
-
+export const validateAppName = (rawInput: string) => {
+  const input = removeTrailingSlash(rawInput);
   const paths = input.split("/");
 
   // If the first part is a @, it's a scoped package

--- a/cli/src/utils/validateAppName.ts
+++ b/cli/src/utils/validateAppName.ts
@@ -3,6 +3,11 @@ const validationRegExp =
 
 //Validate a string against allowed package.json names
 export const validateAppName = (input: string) => {
+  // Ignore potential trailing slash
+  if (input.endsWith("/")) {
+    input = input.slice(0, -1);
+  }
+
   const paths = input.split("/");
 
   // If the first part is a @, it's a scoped package


### PR DESCRIPTION
Closes #1460

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

_Ignore trailing slashes when prompting the app name_

---

## Screenshots

### When prompting `./`

<img width="761" alt="image" src="https://github.com/t3-oss/create-t3-app/assets/50559336/ef32c884-0ed0-43ab-991d-ff2da1ffb723">


### When prompting any path with a trailing slash

<img width="680" alt="image" src="https://github.com/t3-oss/create-t3-app/assets/50559336/9615fdef-1459-4ca4-9660-ffd039ff11a0">

💯
