### PR TITLE
chore: Replace React.FC and NextPage types with basic function syntax

### DIFF
--- a/.changeset/healthy-toes-matter.md
+++ b/.changeset/healthy-toes-matter.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Replace React.FC with basic function syntax

--- a/cli/template/base/src/pages/index.tsx
+++ b/cli/template/base/src/pages/index.tsx
@@ -1,9 +1,8 @@
 import styles from "./index.module.css";
-import { type NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
 
-const Home: NextPage = () => {
+export default function Home() {
   return (
     <>
       <Head>
@@ -44,6 +43,4 @@ const Home: NextPage = () => {
       </main>
     </>
   );
-};
-
-export default Home;
+}

--- a/cli/template/extras/src/pages/index/with-auth-trpc-tw.tsx
+++ b/cli/template/extras/src/pages/index/with-auth-trpc-tw.tsx
@@ -1,10 +1,9 @@
-import { type NextPage } from "next";
 import { signIn, signOut, useSession } from "next-auth/react";
 import Head from "next/head";
 import Link from "next/link";
 import { api } from "~/utils/api";
 
-const Home: NextPage = () => {
+export default function Home() {
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
 
   return (
@@ -53,11 +52,9 @@ const Home: NextPage = () => {
       </main>
     </>
   );
-};
+}
 
-export default Home;
-
-const AuthShowcase: React.FC = () => {
+function AuthShowcase() {
   const { data: sessionData } = useSession();
 
   const { data: secretMessage } = api.example.getSecretMessage.useQuery(
@@ -79,4 +76,4 @@ const AuthShowcase: React.FC = () => {
       </button>
     </div>
   );
-};
+}

--- a/cli/template/extras/src/pages/index/with-auth-trpc.tsx
+++ b/cli/template/extras/src/pages/index/with-auth-trpc.tsx
@@ -1,11 +1,10 @@
 import styles from "./index.module.css";
-import { type NextPage } from "next";
 import { signIn, signOut, useSession } from "next-auth/react";
 import Head from "next/head";
 import Link from "next/link";
 import { api } from "~/utils/api";
 
-const Home: NextPage = () => {
+export default function Home() {
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
 
   return (
@@ -54,11 +53,9 @@ const Home: NextPage = () => {
       </main>
     </>
   );
-};
+}
 
-export default Home;
-
-const AuthShowcase: React.FC = () => {
+function AuthShowcase() {
   const { data: sessionData } = useSession();
 
   const { data: secretMessage } = api.example.getSecretMessage.useQuery(
@@ -80,4 +77,4 @@ const AuthShowcase: React.FC = () => {
       </button>
     </div>
   );
-};
+}

--- a/cli/template/extras/src/pages/index/with-trpc-tw.tsx
+++ b/cli/template/extras/src/pages/index/with-trpc-tw.tsx
@@ -1,9 +1,8 @@
-import { type NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
 import { api } from "~/utils/api";
 
-const Home: NextPage = () => {
+export default function Home() {
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
 
   return (
@@ -49,6 +48,4 @@ const Home: NextPage = () => {
       </main>
     </>
   );
-};
-
-export default Home;
+}

--- a/cli/template/extras/src/pages/index/with-trpc.tsx
+++ b/cli/template/extras/src/pages/index/with-trpc.tsx
@@ -1,10 +1,9 @@
 import styles from "./index.module.css";
-import { type NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
 import { api } from "~/utils/api";
 
-const Home: NextPage = () => {
+export default function Home() {
   const hello = api.example.hello.useQuery({ text: "from tRPC" });
 
   return (
@@ -50,6 +49,4 @@ const Home: NextPage = () => {
       </main>
     </>
   );
-};
-
-export default Home;
+}

--- a/cli/template/extras/src/pages/index/with-tw.tsx
+++ b/cli/template/extras/src/pages/index/with-tw.tsx
@@ -1,8 +1,7 @@
-import { type NextPage } from "next";
 import Head from "next/head";
 import Link from "next/link";
 
-const Home: NextPage = () => {
+export default function Home() {
   return (
     <>
       <Head>
@@ -43,6 +42,4 @@ const Home: NextPage = () => {
       </main>
     </>
   );
-};
-
-export default Home;
+}


### PR DESCRIPTION
Closes https://twitter.com/ccccjjjjeeee/status/1668694515484336145

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Remove React.FC usage in templates, replacing with standard function syntax

Per https://twitter.com/ccccjjjjeeee/status/1668694515484336145

---

## Screenshots

<img width="1432" alt="Screen Shot 2023-06-13 at 2 24 08 PM" src="https://github.com/t3-oss/create-t3-app/assets/12574949/afb35982-5ce6-40cd-aec9-f6758eafeb83">


💯
