### PR TITLE
feat: use custom error class for isTTYError

### DIFF
--- a/.changeset/funny-spoons-unite.md
+++ b/.changeset/funny-spoons-unite.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+use custom error class for IsTTYError

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -6,6 +6,7 @@ import { type AvailablePackages } from "~/installers/index.js";
 import { availablePackages } from "~/installers/index.js";
 import { getVersion } from "~/utils/getT3Version.js";
 import { getUserPkgManager } from "~/utils/getUserPkgManager.js";
+import { IsTTYError } from "~/utils/isTTYError.js";
 import { logger } from "~/utils/logger.js";
 import { validateAppName } from "~/utils/validateAppName.js";
 import { validateImportAlias } from "~/utils/validateImportAlias.js";
@@ -162,10 +163,7 @@ export const runCli = async () => {
   using Git Bash. If that's that case, please use Git Bash from another terminal, such as Windows Terminal. Alternatively, you 
   can provide the arguments from the CLI directly: https://create.t3.gg/en/installation#experimental-usage to skip the prompts.`);
 
-      const error = new Error("Non-interactive environment");
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (error as any).isTTYError = true;
-      throw error;
+      throw new IsTTYError("Non-interactive environment");
     }
 
     // if --CI flag is set, we are running in CI mode and should not prompt the user
@@ -188,11 +186,9 @@ export const runCli = async () => {
       cliResults.flags.importAlias = await promptImportAlias();
     }
   } catch (err) {
-    // If the user is not calling create-t3-app from an interactive terminal, inquirer will throw an error with isTTYError = true
+    // If the user is not calling create-t3-app from an interactive terminal, inquirer will throw an IsTTYError
     // If this happens, we catch the error, tell the user what has happened, and then continue to run the program with a default t3 app
-    // Otherwise we have to do some fancy namespace extension logic on the Error type which feels overkill for one line
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if (err instanceof Error && (err as any).isTTYError) {
+    if (err instanceof IsTTYError) {
       logger.warn(`
   ${CREATE_T3_APP} needs an interactive terminal to provide options`);
 

--- a/cli/src/utils/isTTYError.ts
+++ b/cli/src/utils/isTTYError.ts
@@ -1,0 +1,5 @@
+export class IsTTYError extends Error {
+  constructor(msg: string) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Adds IsTTYError class and checks for instanceof that, instead of assigning an `isTTYError` key to a normal error. Extending the Error class for one-time use feels like a good tradeoff for not needing ESLint ignores and not having to write `if (err instanceof Error && (err as any).isTTYError)`.

💯
