### PR TITLE
fix(nextauth-drizzle): changed varchar to text on drizzle nextauth to prevent auth errors

### DIFF
--- a/cli/template/extras/src/server/db/drizzle-schema-auth.ts
+++ b/cli/template/extras/src/server/db/drizzle-schema-auth.ts
@@ -6,6 +6,7 @@ import {
   primaryKey,
   serial,
   uniqueIndex,
+  text,
 } from "drizzle-orm/mysql-core";
 import { type AdapterAccount } from "next-auth/adapters";
 
@@ -37,12 +38,12 @@ export const accounts = mysqlTable(
       .notNull(),
     provider: varchar("provider", { length: 255 }).notNull(),
     providerAccountId: varchar("providerAccountId", { length: 255 }).notNull(),
-    refresh_token: varchar("refresh_token", { length: 255 }),
-    access_token: varchar("access_token", { length: 255 }),
+    refresh_token: text("refresh_token"),
+    access_token: text("access_token"),
     expires_at: int("expires_at"),
     token_type: varchar("token_type", { length: 255 }),
     scope: varchar("scope", { length: 255 }),
-    id_token: varchar("id_token", { length: 255 }),
+    id_token: text("id_token"),
     session_state: varchar("session_state", { length: 255 }),
   },
   (account) => ({


### PR DESCRIPTION
Closes #1485 

## ✅ Checklist

- [| ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [ |] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [| ] I performed a functional test on my final commit

---

## Changelog

_[Short description of what has changed]_
in the nextauth drizzle template I changes varchar to text on some fields to prevent errors when authenticating
---

