### PR TITLE
fix: add spacing between github icon and star bubble icon

### DIFF
--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -22,7 +22,7 @@ const isRtl = getIsRtlFromUrl(pathname);
 <a
   id="github-link"
   href="https://github.com/t3-oss/create-t3-app"
-  class="group flex items-center rounded-lg no-underline"
+  class="group flex items-center rounded-lg no-underline gap-1"
   aria-label="github repository link"
 >
   <div

--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -22,7 +22,7 @@ const isRtl = getIsRtlFromUrl(pathname);
 <a
   id="github-link"
   href="https://github.com/t3-oss/create-t3-app"
-  class="group flex items-center rounded-lg no-underline gap-1"
+  class="group flex items-center gap-1 rounded-lg no-underline"
   aria-label="github repository link"
 >
   <div


### PR DESCRIPTION
Closes #1488 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

added spacing between github icon and star bubble icon

---

## Screenshots

| before | after | 
| --- | --- |
| ![image](https://github.com/t3-oss/create-t3-app/assets/74069208/0be4c22c-44fd-4a1b-8d2d-cf0114d794e6) | ![image](https://github.com/t3-oss/create-t3-app/assets/74069208/75b50c60-a729-4725-9164-bacb715bbf06) |


💯
