### PR TITLE
feat: override defaults

### DIFF
--- a/cli/src/helpers/overrideDefaults.ts
+++ b/cli/src/helpers/overrideDefaults.ts
@@ -1,0 +1,40 @@
+import chalk from "chalk";
+import fs from "fs-extra";
+import { Ora } from "ora";
+import path from "path";
+import { env } from "process";
+
+// this function first checks if one of the following env variables is set
+// T3_CONFIG, XDG_CONFIG_HOME, HOME
+// if so given path is joined with t3stack/ (unless it's the T3_CONFIG var, then it uses the directory directly) and override/
+// then the first path, which exists, is returned
+const getOverridePath = (): string | undefined => {
+  return ["T3_CONFIG", "XDG_CONFIG_HOME", "HOME"]
+    .map((key) => [key, env[key]])
+    .filter(([_, envValue]) => envValue !== undefined)
+    .map(([envKey, envValue]) =>
+      path.join(
+        envValue as string,
+        envKey === "T3_CONFIG" ? "." : "t3stack",
+        "override"
+      )
+    )
+    .find(fs.existsSync);
+};
+
+export const overrideDefaults = (spinner: Ora, projectPath: string) => {
+  const overridePath = getOverridePath();
+  if (!overridePath) return;
+
+  spinner.info(
+    chalk.green(
+      `Found override directory - ${chalk.bgGreen(chalk.white(overridePath))}`
+    )
+  );
+
+  fs.copySync(overridePath, projectPath, { overwrite: true });
+
+  spinner.info(
+    chalk.green("Successfully override files in just created project")
+  );
+};

--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -1,3 +1,4 @@
+import { overrideDefaults } from "./overrideDefaults.js";
 import chalk from "chalk";
 import fs from "fs-extra";
 import inquirer from "inquirer";
@@ -102,6 +103,8 @@ export const scaffoldProject = async ({
 
   const scaffoldedName =
     projectName === "." ? "App" : chalk.cyan.bold(projectName);
+
+  overrideDefaults(spinner, projectDir);
 
   spinner.succeed(
     `${scaffoldedName} ${chalk.green("scaffolded successfully!")}\n`


### PR DESCRIPTION
Closes #1078

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

I've implemented a function which is called at the end of the scaffold, which then looks up some default places for configs and if there's a t3stack directory (optionally the config dir can be configured by the T3_CONFIG env var directly), if so it checks if that contains a override/ directory, which then is copied into the just scaffolded project.

On the screenshots i've wrote overwrites but changed it to overrides as a quick google search confirmed, that it's the correct term in this case 😅 

---

## Screenshots
Without any config dir nothing changes
![](https://cdn.discordapp.com/attachments/1126478322482806945/1126729417729773588/image.png)

When having a t3stack inside the XDG_CONFIG_HOME with a file to overwrite
![](https://cdn.discordapp.com/attachments/1126478322482806945/1126731253375324241/image.png)

It uses it to scaffold the project
![](https://cdn.discordapp.com/attachments/1126478322482806945/1126731713154928742/image.png)

And it also works with the T3_CONFIG/override
![](https://cdn.discordapp.com/attachments/1126478322482806945/1126732563965280256/image.png)

💯
