### PR TITLE
chore(deps): upgrade Prisma to v5.1.1, bump patch versions of other dependencies

### DIFF
--- a/.changeset/few-bikes-collect.md
+++ b/.changeset/few-bikes-collect.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+chore(deps): upgrade Prisma to v5.1.1, bump patch versions of other dependencies

--- a/cli/src/installers/dependencyVersionMap.ts
+++ b/cli/src/installers/dependencyVersionMap.ts
@@ -4,17 +4,17 @@
  */
 export const dependencyVersionMap = {
   // NextAuth.js
-  "next-auth": "^4.22.1",
+  "next-auth": "^4.22.4",
   "@next-auth/prisma-adapter": "^1.0.7",
 
   // Prisma
-  prisma: "^5.0.0",
-  "@prisma/client": "^5.0.0",
+  prisma: "^5.1.1",
+  "@prisma/client": "^5.1.1",
 
   // TailwindCSS
   tailwindcss: "^3.3.3",
   autoprefixer: "^10.4.14",
-  postcss: "^8.4.26",
+  postcss: "^8.4.27",
   prettier: "^2.8.8",
   "prettier-plugin-tailwindcss": "^0.2.8",
   "@types/prettier": "^2.7.2",


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

* Bump Prisma from ^5.0.0 to ^5.1.1
  * Notably, [Prisma v5.1.0](https://github.com/prisma/prisma/releases/tag/5.1.0) removes some redundant queries for PostgreSQL and CockroachDB 🎉 
* Bump patch versions of a couple other deps while in the area

---

## Screenshots

n/a