### PR TITLE
fix(website): make right-click ➝ /branding only for logo, not entire navbar

### DIFF
--- a/www/src/components/navigation/navbar.astro
+++ b/www/src/components/navigation/navbar.astro
@@ -39,12 +39,11 @@ const navbarLinks: Array<{ href: string; label: string }> = [
     },
   ]}
   aria-label="Global"
-  data-navbar
 >
   <div class="flex w-full max-w-7xl items-center justify-between px-4">
     <div class="flex w-full items-center justify-between md:w-auto">
       <div>
-        <a href="/" class="flex" title="Home">
+        <a href="/" class="flex" title="Home" data-home-link>
           <img
             class="block dark:hidden"
             width="50"
@@ -114,7 +113,7 @@ const navbarLinks: Array<{ href: string; label: string }> = [
   </div>
 </nav>
 <script>
-  const logo = document.querySelector("[data-navbar]") as HTMLElement;
+  const logo = document.querySelector("[data-home-link]") as HTMLAnchorElement;
 
   logo.addEventListener("contextmenu", (e) => {
     e.preventDefault();


### PR DESCRIPTION
Closes #1552

1. Removed `data-navbar` from navbar.
2. Added `data-home-link` to anchor tag wrapping the logo.
3. Updated selector that applies right-click listener accordingly.

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Minor, website navbar, right-click redirects to `/branding` page only for logo anchor, not entire navbar.

No packages need a version bump, no changeset applicable, website change only.