### PR TITLE
refactor(cli): `bun dev` cmd defaults to dev script

### DIFF
--- a/cli/src/helpers/logNextSteps.ts
+++ b/cli/src/helpers/logNextSteps.ts
@@ -33,11 +33,7 @@ export const logNextSteps = async ({
     );
   }
 
-  if (["npm", "bun"].includes(pkgManager)) {
-    logger.info(`  ${pkgManager} run dev`);
-  } else {
-    logger.info(`  ${pkgManager} dev`);
-  }
+  logger.info(`  ${pkgManager === "npm" ? "npm run" : pkgManager} dev`);
 
   if (!(await isInsideGitRepo(projectDir)) && !isRootGitRepo(projectDir)) {
     logger.info(`  git init`);


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

- changed `bun run dev` to `bun dev` in ct3a cli's next steps as after v1.0, `bun dev` defaults to dev script in package.json
https://bun.sh/blog/bun-v1.0#changelog-since-v0-8

---

## Screenshots

_[Screenshots]_

💯
