### PR TITLE
chore: ship less files to users with the cli

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -26,6 +26,7 @@
     "dist",
     "template",
     "README.md",
+    "LICENSE",
     "CHANGELOG.md",
     ".yarnrc.yml",
     "package.json"

--- a/cli/package.json
+++ b/cli/package.json
@@ -22,6 +22,14 @@
   "bin": {
     "create-t3-app": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "template",
+    "README.md",
+    "CHANGELOG.md",
+    ".yarnrc.yml",
+    "package.json"
+  ],
   "engines": {
     "node": ">=14.16"
   },

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -4,12 +4,9 @@ const isDev = process.env.npm_lifecycle_event === "dev";
 
 export default defineConfig({
   clean: true,
-  dts: true,
   entry: ["src/index.ts"],
   format: ["esm"],
   minify: !isDev,
-  metafile: !isDev,
-  sourcemap: true,
   target: "esnext",
   outDir: "dist",
   onSuccess: isDev ? "node dist/index.js" : undefined,


### PR DESCRIPTION
no need to ship type declarations or src files to users. the CLI already includes a lot of files as is