### PR TITLE
fix(drizzle): yell if default url isn't cahnged

### DIFF
--- a/.changeset/hungry-cameras-melt.md
+++ b/.changeset/hungry-cameras-melt.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: block drizzle apps when the example database url hasn't been changed yet

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
           echo "continue=${{ matrix.prisma == 'false' || matrix.drizzle == 'false' }}" >> $GITHUB_OUTPUT
 
       - name: Install Node.js
-        if: ${{ steps.matrix-valid.outputs.continue == 'true' }} 
+        if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
         uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -74,7 +74,7 @@ jobs:
 
       - run: pnpm turbo --filter=create-t3-app build
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
-        
+
       # has to be scaffolded outside the CLI project so that no lint/tsconfig are leaking
       # through. this way it ensures that it is the app's configs that are being used
       # FIXME: this is a bit hacky, would rather have --packages=trpc,tailwind,... but not sure how to setup the matrix for that
@@ -84,6 +84,7 @@ jobs:
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
         env:
           NEXTAUTH_SECRET: foo
+          DATABASE_URL: mysql://root:root@localhost:3306/test # can't use url from example env cause we block that in t3-env
 
   build-t3-app-with-bun:
     runs-on: ubuntu-latest

--- a/cli/template/extras/src/env/with-auth-db.mjs
+++ b/cli/template/extras/src/env/with-auth-db.mjs
@@ -7,7 +7,13 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    DATABASE_URL: z.string().url(),
+    DATABASE_URL: z
+      .string()
+      .url()
+      .refine(
+        (str) => !str.includes("YOUR_MYSQL_URL_HERE"),
+        "You forgot to change the default URL"
+      ),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
@@ -49,8 +55,8 @@ export const env = createEnv({
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
   },
   /**
-   * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.
-   * This is especially useful for Docker builds.
+   * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially
+   * useful for Docker builds.
    */
   skipValidation: !!process.env.SKIP_ENV_VALIDATION,
 });

--- a/cli/template/extras/src/env/with-db.mjs
+++ b/cli/template/extras/src/env/with-db.mjs
@@ -7,7 +7,13 @@ export const env = createEnv({
    * isn't built with invalid env vars.
    */
   server: {
-    DATABASE_URL: z.string().url(),
+    DATABASE_URL: z
+      .string()
+      .url()
+      .refine(
+        (str) => !str.includes("YOUR_MYSQL_URL_HERE"),
+        "You forgot to change the default URL"
+      ),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),


### PR DESCRIPTION
The default example url is a valid url so t3-env wont crash the app, so your app just silently wont work. Adding a refine checking for the default case to prevent this and make sure the app crash before you've changed the URL