### PR TITLE
fix: replace all incorrect versions

### DIFF
--- a/.changeset/tricky-suns-float.md
+++ b/.changeset/tricky-suns-float.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Updated the NPX links to fix them

--- a/.github/workflows/prerelease-comment.yml
+++ b/.github/workflows/prerelease-comment.yml
@@ -48,7 +48,7 @@ jobs:
             A new create-t3-app prerelease is available for testing. You can install this latest build in your project with:
 
             ```sh
-            pnpm create t3-app@${{ env.BETA_PACKAGE_VERSION }}
+            pnpm create-t3-app@${{ env.BETA_PACKAGE_VERSION }}
             ```
 
       - name: "Remove the autorelease label once published"

--- a/cli/README.md
+++ b/cli/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  Get started with the <a rel="noopener noreferrer" target="_blank" href="https://init.tips">T3 Stack</a> by running <code>npm create t3-app@latest</code>
+  Get started with the <a rel="noopener noreferrer" target="_blank" href="https://init.tips">T3 Stack</a> by running <code>npm create-t3-app@latest</code>
 </p>
 
 <div align="center">
@@ -84,25 +84,25 @@ To scaffold an app using `create-t3-app`, run any of the following four commands
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 For more advanced usage, check out the [CLI docs](https://create.t3.gg/en/installation).

--- a/www/src/components/landingPage/ClipboardSelect.tsx
+++ b/www/src/components/landingPage/ClipboardSelect.tsx
@@ -4,19 +4,19 @@ import { Fragment, useState } from "react";
 
 const commands = [
   {
-    command: "create t3-app@latest",
+    command: "create-t3-app@latest",
     manager: "npm",
   },
   {
-    command: "create t3-app",
+    command: "create-t3-app",
     manager: "yarn",
   },
   {
-    command: "create t3-app@latest",
+    command: "create-t3-app@latest",
     manager: "pnpm",
   },
   {
-    command: "create t3-app@latest",
+    command: "create-t3-app@latest",
     manager: "bun",
   },
 ];

--- a/www/src/components/landingPage/banner.astro
+++ b/www/src/components/landingPage/banner.astro
@@ -73,7 +73,7 @@ import ClipboardSelect from "./ClipboardSelect";
                   <div
                     class="relative flex items-center rounded-lg border border-t3-purple-200/20 bg-t3-purple-100/10 px-2 py-2 text-sm md:px-3 md:py-3 md:text-lg lg:px-5 lg:py-4 lg:text-xl"
                   >
-                    <code class="mr-12">npx create t3-app@latest</code>
+                    <code class="mr-12">npx create-t3-app@latest</code>
                     <ClipboardSelect client:load />
                   </div>
                 </div>

--- a/www/src/components/landingPage/cli.tsx
+++ b/www/src/components/landingPage/cli.tsx
@@ -17,7 +17,7 @@ export default function CodeCard() {
           <div className="ml-2 h-3 w-3 rounded-full bg-green-500"></div>
         </div>
         <Typist cursor={{ hideWhenDone: true, hideWhenDoneDelay: 0 }}>
-          npm create t3-app@latest
+          npm create-t3-app@latest
           <Typist.Delay ms={1250} />
         </Typist>
         <Typist

--- a/www/src/pages/ar/installation.mdx
+++ b/www/src/pages/ar/installation.mdx
@@ -14,25 +14,25 @@ import Callout from "../../components/docs/callout.tsx";
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 بعد أن تَنتهي عَملية إنشاء التطبيق، اَلق نَظرة عَلي [الخطوات الأولى](/ar/usage/first-steps) للبدء في تطبيقك الجديد.

--- a/www/src/pages/en/installation.mdx
+++ b/www/src/pages/en/installation.mdx
@@ -13,25 +13,25 @@ To scaffold an app using `create-t3-app`, run any of the following three command
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 After your app has been scaffolded, check out the [first steps](/en/usage/first-steps) to get started on your new application.

--- a/www/src/pages/es/installation.mdx
+++ b/www/src/pages/es/installation.mdx
@@ -13,25 +13,25 @@ Para crear una aplicación usando `create-t3-app`, ejecuta cualquiera de los sig
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 Después de que tu aplicación haya sido creada, consulta los [primeros pasos](/es/usage/first-steps) para comenzar con tu nueva aplicación.

--- a/www/src/pages/fr/installation.mdx
+++ b/www/src/pages/fr/installation.mdx
@@ -13,25 +13,25 @@ Pour configurer une application à l'aide de `create-t3-app`, exécutez l'une de
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 Une fois votre application configurée, consultez les [premières étapes](/fr/usage/first-steps) pour démarrer sur votre nouvelle application.

--- a/www/src/pages/ja/installation.mdx
+++ b/www/src/pages/ja/installation.mdx
@@ -13,25 +13,25 @@ import Callout from "../../components/docs/callout.tsx";
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 アプリケーションの初期構成が生成されたら、[ファーストステップ](/ja/usage/first-steps) をチェックして、新しいアプリケーションを開始しましょう。

--- a/www/src/pages/no/installation.mdx
+++ b/www/src/pages/no/installation.mdx
@@ -13,25 +13,25 @@ For å lage en app med `create-t3-app`, kjør en av følgende tre kommandoer og 
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 Etter at applikasjonen din har blitt opprettet, sjekk ut [første steg](/no/usage/first-steps) for å begynne å utvikle den nye applikasjonen.

--- a/www/src/pages/pl/installation.mdx
+++ b/www/src/pages/pl/installation.mdx
@@ -13,25 +13,25 @@ Aby zacząć używać szablonu `create-t3-app`, uruchom którąkolwiek z poniżs
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 Po tym, jak szablon aplikacji zostanie utworzony, sprawdź [pierwsze kroki](/pl/usage/first-steps) aby zacząć budować swoją nową aplikację.

--- a/www/src/pages/pt/installation.mdx
+++ b/www/src/pages/pt/installation.mdx
@@ -13,25 +13,25 @@ Para estruturar uma aplicação usando `create-t3-app`, rode qualquer um dos com
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 Após sua aplicação ter sido estruturada, verifique os [Primeiros Passos](/pt/usage/first-steps) para começar a usar sua nova aplicação.

--- a/www/src/pages/ru/installation.mdx
+++ b/www/src/pages/ru/installation.mdx
@@ -13,25 +13,25 @@ import Callout from "../../components/docs/callout.tsx";
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 После того, как приложение будет создано, ознакомьтесь с [первыми шагами](/ru/usage/first-steps), чтобы начать работу над вашим новым приложением.

--- a/www/src/pages/zh-hans/installation.mdx
+++ b/www/src/pages/zh-hans/installation.mdx
@@ -13,25 +13,25 @@ import Callout from "../../components/docs/callout.tsx";
 ### npm
 
 ```bash
-npm create t3-app@latest
+npm create-t3-app@latest
 ```
 
 ### yarn
 
 ```bash
-yarn create t3-app
+yarn create-t3-app
 ```
 
 ### pnpm
 
 ```bash
-pnpm create t3-app@latest
+pnpm create-t3-app@latest
 ```
 
 ### bun
 
 ```bash
-bun create t3-app@latest
+bun create-t3-app@latest
 ```
 
 在你的应用程序被创建后，请查看 [第一步](/zh-hans/usage/first-steps) 以开始你的新应用。


### PR DESCRIPTION
goes through the repo and replaces all incorrect versions of create t3-app with  create-t3-app This closes 1620

Closes #1620 

## ✅ Checklist

- [✅] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [✅ ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [✅ ] I performed a functional test on my final commit

---

## Changelog

All incorrect versions of the npx command have been replaced

---

## Screenshots
Old
![image](https://github.com/t3-oss/create-t3-app/assets/5090163/9b199fcb-a4c8-47a8-8060-7113534f112f)
New
![image](https://github.com/t3-oss/create-t3-app/assets/5090163/eeb1d586-81fb-403b-8bd7-e9275fe3613d)

💯
