### PR TITLE
fix: prevent tRPC breaking when revalidating pages

### DIFF
--- a/.changeset/old-worms-exist.md
+++ b/.changeset/old-worms-exist.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix tRPC breaking when `revalidatePage` is used

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -30,6 +30,7 @@ export function TRPCReactProvider(props: {
           headers() {
             const heads = new Map(props.headers);
             heads.set("x-trpc-source", "react");
+            heads.delete("content-length");
             return Object.fromEntries(heads);
           },
         }),

--- a/cli/template/extras/src/trpc/server.ts
+++ b/cli/template/extras/src/trpc/server.ts
@@ -21,6 +21,7 @@ export const api = createTRPCProxyClient<AppRouter>({
       headers() {
         const heads = new Map(headers());
         heads.set("x-trpc-source", "rsc");
+        heads.delete("content-length");
         return Object.fromEntries(heads);
       },
     }),


### PR DESCRIPTION
Closes #1640

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Prevent tRPC from breaking when a `revalidateTag` or `revalidatePage` is used inside a server action that targets the page it's on.

---

## Screenshots

_N/A_

💯
