### PR TITLE
fix: only forward required cookie header

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "next",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["@ct3a/www", "@ct3a/upgrade"],
   "changedFilePatterns": ["src/**", "template/**"]

--- a/.changeset/smooth-radios-sparkle.md
+++ b/.changeset/smooth-radios-sparkle.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: only forward required cookie header

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,11 @@ jobs:
 
       - name: Check and Validate Changes in /cli
         run: |
-          git fetch origin next:next
-          changes=$(git diff --name-only next...${{ github.sha }} | grep '^cli/' || true)
+          git fetch origin main:main
+          changes=$(git diff --name-only main...${{ github.sha }} | grep '^cli/' || true)
           if [[ -n "$changes" ]]; then
             echo "Changes detected in /cli: $changes"
-            pnpm changeset status --since origin/next
+            pnpm changeset status --since origin/main
             exit_status=$?
             if [[ $exit_status -eq 0 ]]; then
               echo "Changeset validation succeeded."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ and fill out the title and body appropriately. Again, make sure to follow the [c
 
 ## Translations
 
-For more information on how to help with translation, please see the [contributing guidelines for our docs](https://github.com/t3-oss/create-t3-app/blob/next/www/TRANSLATIONS.md).
+For more information on how to help with translation, please see the [contributing guidelines for our docs](https://github.com/t3-oss/create-t3-app/blob/main/www/TRANSLATIONS.md).
 
 ## Credits
 

--- a/cli/template/extras/src/app/layout/with-trpc-tw.tsx
+++ b/cli/template/extras/src/app/layout/with-trpc-tw.tsx
@@ -1,7 +1,7 @@
 import "~/styles/globals.css";
 
 import { Inter } from "next/font/google";
-import { headers } from "next/headers";
+import { cookies } from "next/headers";
 
 import { TRPCReactProvider } from "~/trpc/react";
 
@@ -24,7 +24,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`font-sans ${inter.variable}`}>
-        <TRPCReactProvider headers={headers()}>{children}</TRPCReactProvider>
+        <TRPCReactProvider cookies={cookies().toString()}>
+          {children}
+        </TRPCReactProvider>
       </body>
     </html>
   );

--- a/cli/template/extras/src/app/layout/with-trpc.tsx
+++ b/cli/template/extras/src/app/layout/with-trpc.tsx
@@ -1,7 +1,7 @@
 import "~/styles/globals.css";
 
 import { Inter } from "next/font/google";
-import { headers } from "next/headers";
+import { cookies } from "next/headers";
 
 import { TRPCReactProvider } from "~/trpc/react";
 
@@ -23,7 +23,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <TRPCReactProvider headers={headers()}>{children}</TRPCReactProvider>
+        <TRPCReactProvider cookies={cookies().toString()}>
+          {children}
+        </TRPCReactProvider>
       </body>
     </html>
   );

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -12,7 +12,7 @@ export const api = createTRPCReact<AppRouter>();
 
 export function TRPCReactProvider(props: {
   children: React.ReactNode;
-  headers: Headers;
+  cookies: string;
 }) {
   const [queryClient] = useState(() => new QueryClient());
 
@@ -28,9 +28,10 @@ export function TRPCReactProvider(props: {
         unstable_httpBatchStreamLink({
           url: getUrl(),
           headers() {
-            const heads = new Map(props.headers);
-            heads.set("x-trpc-source", "react");
-            return Object.fromEntries(heads);
+            return {
+              cookie: props.cookies,
+              "x-trpc-source": "react",
+            };
           },
         }),
       ],

--- a/cli/template/extras/src/trpc/server.ts
+++ b/cli/template/extras/src/trpc/server.ts
@@ -3,7 +3,7 @@ import {
   loggerLink,
   unstable_httpBatchStreamLink,
 } from "@trpc/client";
-import { headers } from "next/headers";
+import { cookies } from "next/headers";
 
 import { type AppRouter } from "~/server/api/root";
 import { getUrl, transformer } from "./shared";
@@ -19,9 +19,10 @@ export const api = createTRPCProxyClient<AppRouter>({
     unstable_httpBatchStreamLink({
       url: getUrl(),
       headers() {
-        const heads = new Map(headers());
-        heads.set("x-trpc-source", "rsc");
-        return Object.fromEntries(heads);
+        return {
+          cookie: cookies().toString(),
+          "x-trpc-source": "rsc",
+        };
       },
     }),
   ],


### PR DESCRIPTION
We only really need to forward the header so that tRPC and other stuff can authenticate the user. There are some issues with certain headers that we run into when sending every single header along (I know `transfer-encoding` and `content-length` are two that doesn't like playing nice)

Closes #1640
Closes #1641