### PR TITLE
fix: replace a `2` with `"error"` in eslint config

### DIFF
--- a/.changeset/smooth-buckets-search.md
+++ b/.changeset/smooth-buckets-search.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+chore: replace a `2` with `"error"` in eslint config

--- a/cli/template/base/_eslintrc.cjs
+++ b/cli/template/base/_eslintrc.cjs
@@ -25,7 +25,7 @@ const config = {
     ],
     "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
     "@typescript-eslint/no-misused-promises": [
-      2,
+      "error",
       {
         checksVoidReturn: { attributes: false },
       },


### PR DESCRIPTION
## ✅ Checklist

- [ ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

A simple consistency fix