### PR TITLE
fix: Use the correct types for `prettier-plugin-tailwindcss`

### DIFF
--- a/.changeset/nervous-seals-reflect.md
+++ b/.changeset/nervous-seals-reflect.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: Use the correct types for `prettier-plugin-tailwindcss`

--- a/cli/prettier.config.mjs
+++ b/cli/prettier.config.mjs
@@ -1,7 +1,7 @@
 import baseConfig from "../prettier.config.mjs";
 
 /**
- * @type {import('prettier').Config & import('prettier-plugin-tailwindcss').options &
+ * @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions &
  *       import("@ianvs/prettier-plugin-sort-imports").PluginConfig}
  */
 const config = {

--- a/cli/template/extras/config/_prettier.config.js
+++ b/cli/template/extras/config/_prettier.config.js
@@ -1,4 +1,4 @@
-/** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').options} */
+/** @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions} */
 const config = {
   plugins: ["prettier-plugin-tailwindcss"],
 };

--- a/upgrade/prettier.config.js
+++ b/upgrade/prettier.config.js
@@ -1,7 +1,7 @@
 import baseConfig from "../prettier.config.mjs";
 
 /**
- * @type {import('prettier').Config & import('prettier-plugin-tailwindcss').options &
+ * @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions &
  *       import("@ianvs/prettier-plugin-sort-imports").PluginConfig}
  */
 const config = {

--- a/www/prettier.config.mjs
+++ b/www/prettier.config.mjs
@@ -1,7 +1,7 @@
 import baseConfig from "../prettier.config.mjs";
 
 /**
- * @type {import('prettier').Config & import('prettier-plugin-tailwindcss').options &
+ * @type {import('prettier').Config & import('prettier-plugin-tailwindcss').PluginOptions &
  *       import("@ianvs/prettier-plugin-sort-imports").PluginConfig}
  */
 const config = {


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Use the correct types for `prettier-plugin-tailwindcss`

---

## Screenshots

_[Screenshots]_

💯
