### PR TITLE
[Drizzle] Added script for migration and seeding 

### DIFF
--- a/cli/src/installers/drizzle.ts
+++ b/cli/src/installers/drizzle.ts
@@ -56,6 +56,8 @@ export const drizzleInstaller: Installer = ({
     ...packageJsonContent.scripts,
     "db:push": "dotenv drizzle-kit push:mysql",
     "db:studio": "dotenv drizzle-kit studio",
+    "db:migrate": "dotenv drizzle-kit generate:mysql",
+    "db:seed": "dotenv npx tsx ./src/server/db/seed.ts",
   };
 
   fs.copySync(configFile, configDest);

--- a/cli/src/installers/drizzle.ts
+++ b/cli/src/installers/drizzle.ts
@@ -34,6 +34,8 @@ export const drizzleInstaller: Installer = ({
       ? "drizzle-schema-auth.ts"
       : "drizzle-schema-base.ts"
   );
+
+  const seedSrc = path.join(extrasDir, "src/server/db/drizzle-seed.ts")
   const schemaDest = path.join(projectDir, "src/server/db/schema.ts");
 
   // Replace placeholder table prefix with project name
@@ -42,6 +44,12 @@ export const drizzleInstaller: Installer = ({
     "project1_${name}",
     `${scopedAppName}_\${name}`
   );
+
+  
+  let seedDest = path.join(projectDir, "src/server/db/seed.ts");
+  let seedContent = fs.readFileSync(seedSrc, "utf-8");
+
+
   let configContent = fs.readFileSync(configFile, "utf-8");
   configContent = configContent.replace("project1_*", `${scopedAppName}_*`);
 
@@ -63,6 +71,7 @@ export const drizzleInstaller: Installer = ({
   fs.copySync(configFile, configDest);
   fs.mkdirSync(path.dirname(schemaDest), { recursive: true });
   fs.writeFileSync(schemaDest, schemaContent);
+  fs.writeFileSync(seedDest, seedContent);
   fs.writeFileSync(configDest, configContent);
   fs.copySync(clientSrc, clientDest);
   fs.writeJSONSync(packageJsonPath, packageJsonContent, {

--- a/cli/template/extras/config/drizzle.config.ts
+++ b/cli/template/extras/config/drizzle.config.ts
@@ -4,6 +4,7 @@ import { env } from "~/env";
 
 export default {
   schema: "./src/server/db/schema.ts",
+  out: "./drizzle/migrations",
   driver: "mysql2",
   dbCredentials: {
     connectionString: env.DATABASE_URL,

--- a/cli/template/extras/src/server/db/drizzle-seed.ts
+++ b/cli/template/extras/src/server/db/drizzle-seed.ts
@@ -1,0 +1,6 @@
+import { db } from ".";
+import { posts } from "./schema";
+
+const firstPost = await db.insert(posts).values({
+    name: "My first blog post",
+});


### PR DESCRIPTION


## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

- Added new scripts to do migrations and seeding for projects that use Drizzle

````diff
 packageJsonContent.scripts = {
    ...packageJsonContent.scripts,
    "db:push": "dotenv drizzle-kit push:mysql",
    "db:studio": "dotenv drizzle-kit studio",
+   "db:migrate": "dotenv drizzle-kit generate:mysql",
+   "db:seed": "dotenv npx tsx ./src/server/db/seed.ts",
  };
}
````

- Added basic seeding data for post

````ts

import { db } from ".";
import { posts } from "./schema";

const firstPost = await db.insert(posts).values({
    name: "My first blog post",
});

````



---

## Screenshots


