### PR TITLE
chore: reuse existing AppRouter type

### DIFF
--- a/cli/template/extras/src/trpc/server.ts
+++ b/cli/template/extras/src/trpc/server.ts
@@ -11,7 +11,7 @@ import { type TRPCErrorResponse } from "@trpc/server/rpc";
 import { cookies } from "next/headers";
 import { cache } from "react";
 
-import { appRouter } from "~/server/api/root";
+import { appRouter, type AppRouter } from "~/server/api/root";
 import { createTRPCContext } from "~/server/api/trpc";
 import { transformer } from "./shared";
 
@@ -28,7 +28,7 @@ const createContext = cache(() => {
   });
 });
 
-export const api = createTRPCProxyClient<typeof appRouter>({
+export const api = createTRPCProxyClient<AppRouter>({
   transformer,
   links: [
     loggerLink({


### PR DESCRIPTION
Minor update to reuse existing `AppRouter` type via import.