### PR TITLE
fix(docs): reserve height for breadcrumbs on server render

### DIFF
--- a/www/src/components/docs/breadCrumbs.tsx
+++ b/www/src/components/docs/breadCrumbs.tsx
@@ -66,7 +66,7 @@ export default function BreadCrumbs() {
     });
 
   return (
-    <div className="mb-4 flex items-center gap-2 px-4 text-sm">
+    <div className="flex items-center gap-2 px-4 text-sm">
       <a
         href="/"
         className="rounded-lg border bg-t3-purple-200/50 p-1 hover:bg-t3-purple-200/75 hover:no-underline dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50"

--- a/www/src/components/docs/pageContent.astro
+++ b/www/src/components/docs/pageContent.astro
@@ -23,7 +23,7 @@ const isRtl = getIsRtlFromLangCode((lang || "en") as KnownLanguageCode);
 
 <article id="article" class="flex w-full max-w-screen-lg flex-col">
   {lang && lang !== "en" && <OutdatedDocsBanner path={path} />}
-  <div>
+  <div class="mb-4 h-8">
     <BreadCrumbs client:only />
   </div>
   <OnThisPageLinks


### PR DESCRIPTION
Closes #1711

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Move the margin and height to the `div` wrapping the `BreadCrumbs` component.

---

## Screenshots

Before:

https://github.com/t3-oss/create-t3-app/assets/1545970/2d6976e3-def1-4529-a462-9a60da242706

After:

https://github.com/t3-oss/create-t3-app/assets/1545970/78fc8e51-0ab3-4c19-bd73-fe772a3acb93


