### PR TITLE
chore(www): update github urls to use `main` branch

### DIFF
--- a/www/src/components/docs/avatarList.astro
+++ b/www/src/components/docs/avatarList.astro
@@ -8,7 +8,7 @@ export interface Props {
 const { path } = Astro.props;
 const resolvedPath = `www/${path}`;
 const url = `https://api.github.com/repos/t3-oss/create-t3-app/commits?path=${resolvedPath}`;
-const commitsURL = `https://github.com/t3-oss/create-t3-app/commits/next/${resolvedPath}`;
+const commitsURL = `https://github.com/t3-oss/create-t3-app/commits/main/${resolvedPath}`;
 
 async function getCommits(url: string) {
   try {

--- a/www/src/components/navigation/moreMenu.astro
+++ b/www/src/components/navigation/moreMenu.astro
@@ -63,7 +63,7 @@ const isLangEN = getLanguageFromURL(pathname) === "en";
     >
       <a
         class="flex items-center gap-2"
-        href={"https://github.com/t3-oss/create-t3-app/blob/next/www/TRANSLATIONS.md"}
+        href={"https://github.com/t3-oss/create-t3-app/blob/main/www/TRANSLATIONS.md"}
         target="_blank"
         rel="noreferrer"
       >

--- a/www/src/config.ts
+++ b/www/src/config.ts
@@ -40,7 +40,7 @@ export const KNOWN_LANGUAGES = {
 } as const;
 export type KnownLanguageCode = keyof typeof KNOWN_LANGUAGES;
 
-export const GITHUB_EDIT_URL = `https://github.com/t3-oss/create-t3-app/tree/next/www`;
+export const GITHUB_EDIT_URL = `https://github.com/t3-oss/create-t3-app/tree/main/www`;
 
 export const COMMUNITY_INVITE_URL = `https://t3.gg/discord`;
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Updates edit links, translation links, and contributor links to use the `main` branch instead of the old `next` branch.

---

## Screenshots

Before:
![image](https://github.com/t3-oss/create-t3-app/assets/50563138/082a295f-03fd-45ab-a803-538c8c1e43fa)

After:
![image](https://github.com/t3-oss/create-t3-app/assets/50563138/2dda34c1-2891-442d-bba7-9f77b73d2206)

💯
