### PR TITLE
docs: Open Collection Links in new Tab

### DIFF
--- a/www/src/components/docs/openSourceAppList.tsx
+++ b/www/src/components/docs/openSourceAppList.tsx
@@ -287,10 +287,14 @@ export default function OpenSourceAppList({
         <tr>
           <td>{project.description}</td>
           <td>
-            <a href={project.repo}>{project.repoName}</a>
+            <a href={project.repo} target="_blank">
+              {project.repoName}
+            </a>
           </td>
           <td>
-            <a href={project.link}>{project.linkName}</a>
+            <a href={project.link} target="_blank">
+              {project.linkName}
+            </a>
             {project.linkExtra && <span> {project.linkExtra}</span>}
           </td>
         </tr>


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Add the the `target="_blank" `attribute to the Collection list to open the link in a new browser tab

---

## Screenshots

_not applicable_
