### PR TITLE
fix: correct casing of “PlanetScale”

### DIFF
--- a/.changeset/dirty-birds-own.md
+++ b/.changeset/dirty-birds-own.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: correct casing of “PlanetScale”

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -287,7 +287,7 @@ export const runCli = async (): Promise<CliResults> => {
               { value: "sqlite", label: "SQLite" },
               { value: "mysql", label: "MySQL" },
               { value: "postgres", label: "PostgreSQL" },
-              { value: "planetscale", label: "Planetscale" },
+              { value: "planetscale", label: "PlanetScale" },
             ],
             initialValue: "sqlite",
           });

--- a/www/src/pages/ar/usage/prisma.md
+++ b/www/src/pages/ar/usage/prisma.md
@@ -77,4 +77,4 @@ main()
 | Prisma Docs                  | https://www.prisma.io/docs/                                                                                                                       |
 | Prisma GitHub                | https://github.com/prisma/prisma                                                                                                                  |
 | NextAuth.JS Prisma Adapter   | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Planetscale Connection Guide | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| PlanetScale Connection Guide | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |

--- a/www/src/pages/en/usage/prisma.md
+++ b/www/src/pages/en/usage/prisma.md
@@ -75,4 +75,4 @@ Then, just run `pnpm db-seed` (or `npm`/`yarn`) to seed your database.
 | Prisma GitHub                | https://github.com/prisma/prisma                                                                                                                  |
 | Prisma Migrate Playground    | https://playground.prisma.io/guides                                                                                                               |
 | NextAuth.JS Prisma Adapter   | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Planetscale Connection Guide | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| PlanetScale Connection Guide | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |

--- a/www/src/pages/fr/usage/prisma.md
+++ b/www/src/pages/fr/usage/prisma.md
@@ -74,4 +74,4 @@ Ensuite, exécutez simplement `pnpm db-seed` (ou `npm`/`yarn`) pour amorcer votr
 | Documentation Prisma               | https://www.prisma.io/docs/                                                                                                                       |
 | Prisma GitHub                      | https://github.com/prisma/prisma                                                                                                                  |
 | Adaptateur Prisma pour NextAuth.JS | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Guide de connexion à Planetscale   | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| Guide de connexion à PlanetScale   | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |

--- a/www/src/pages/ja/usage/prisma.md
+++ b/www/src/pages/ja/usage/prisma.md
@@ -75,4 +75,4 @@ main()
 | Prisma GitHub                           | https://github.com/prisma/prisma                                                                                                                  |
 | Prisma マイグレーションプレイグラウンド | https://playground.prisma.io/guides                                                                                                               |
 | NextAuth.JS Prisma アダプタ             | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Planetscale 接続ガイド                  | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| PlanetScale 接続ガイド                  | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |

--- a/www/src/pages/no/usage/prisma.md
+++ b/www/src/pages/no/usage/prisma.md
@@ -75,4 +75,4 @@ Deretter kan du kjøre `pnpm db-seed` (eller `npm`/`yarn`) for å fylle inn data
 | Prisma GitHub                     | https://github.com/prisma/prisma                                                                                                                  |
 | Prisma Migrate Playground         | https://playground.prisma.io/guides                                                                                                               |
 | NextAuth.JS Prisma Adapter        | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Planetscale Tilkoblingsveiledning | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| PlanetScale Tilkoblingsveiledning | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |

--- a/www/src/pages/pl/usage/prisma.md
+++ b/www/src/pages/pl/usage/prisma.md
@@ -75,4 +75,4 @@ Następnie uruchom po prostu `pnpm db-seed` (lub `npm`/`yarn`) aby wykonać seed
 | GitHub Prismy                     | https://github.com/prisma/prisma                                                                                                                  |
 | Prisma Migrate Playground         | https://playground.prisma.io/guides                                                                                                               |
 | Adapter NextAuth.JS dla Prismy    | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Poradnik Połączenia z Planetscale | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| Poradnik Połączenia z PlanetScale | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |

--- a/www/src/pages/pt/usage/prisma.md
+++ b/www/src/pages/pt/usage/prisma.md
@@ -74,4 +74,4 @@ Em seguida, basta executar `pnpm db-seed` (ou `npm`/`yarn`) para propagar seu ba
 | Documentação do Prisma               | https://www.prisma.io/docs/                                                                                                                       |
 | GitHub do Prisma                     | https://github.com/prisma/prisma                                                                                                                  |
 | Adaptador de Prisma para NextAuth.js | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Guia de Conexão com Planetscale      | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| Guia de Conexão com PlanetScale      | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |

--- a/www/src/pages/zh-hans/usage/prisma.md
+++ b/www/src/pages/zh-hans/usage/prisma.md
@@ -75,4 +75,4 @@ main()
 | Prisma GitHub             | https://github.com/prisma/prisma                                                                                                                  |
 | Prisma Migrate 演练场     | https://playground.prisma.io/guides                                                                                                               |
 | NextAuth.JS Prisma 适配器 | https://next-auth.js.org/adapters/prisma                                                                                                          |
-| Planetscale 连接指引      | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |
+| PlanetScale 连接指引      | https://www.prisma.io/docs/getting-started/setup-prisma/add-to-existing-project/relational-databases/connect-your-database-typescript-planetscale |


### PR DESCRIPTION
~Closes #<issue>~

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Noticed in my last run of `npx create-t3-app` that “PlanetScale” incorrectly appears as “Planetscale” in the prompt (screenshot below). This PR fixes that instance and a few instances across documentation. 

Disclosure: I am a PlanetScale employee 😄

---

## Screenshots

<img width="1136" alt="Screenshot 2024-02-18 at 10 19 38 PM" src="https://github.com/t3-oss/create-t3-app/assets/221550/07696e7c-2499-43e3-af03-d3c1dec0f95b">

💯
