### PR TITLE
fix: stable query client

### DIFF
--- a/.changeset/sixty-rats-drop.md
+++ b/.changeset/sixty-rats-drop.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: use singleton pattern for client-side QueryClient to support `useSuspenseQuery` when there is no parent `<Suspense>`-element

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -8,10 +8,29 @@ import { useState } from "react";
 import { type AppRouter } from "~/server/api/root";
 import { getUrl, transformer } from "./shared";
 
+function makeQueryClient() {
+  return new QueryClient({
+    /* ...opts */
+  });
+}
+
+let clientQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (typeof window === "undefined") {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    if (!clientQueryClient) clientQueryClient = makeQueryClient();
+    return clientQueryClient;
+  }
+}
+
 export const api = createTRPCReact<AppRouter>();
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const queryClient = getQueryClient();
 
   const [trpcClient] = useState(() =>
     api.createClient({

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -8,24 +8,18 @@ import { useState } from "react";
 import { type AppRouter } from "~/server/api/root";
 import { getUrl, transformer } from "./shared";
 
-function makeQueryClient() {
-  return new QueryClient({
-    /* ...opts */
-  });
-}
+const createQueryClient = () => new QueryClient();
 
-let clientQueryClient: QueryClient | undefined = undefined;
-
-function getQueryClient() {
+let clientQueryClientSingleton: QueryClient | undefined = undefined;
+const getQueryClient = () => {
   if (typeof window === "undefined") {
     // Server: always make a new query client
-    return makeQueryClient();
+    return createQueryClient();
   } else {
-    // Browser: make a new query client if we don't already have one
-    if (!clientQueryClient) clientQueryClient = makeQueryClient();
-    return clientQueryClient;
+    // Browser: use singleton pattern to keep the same query client
+    return (clientQueryClientSingleton ??= createQueryClient());
   }
-}
+};
 
 export const api = createTRPCReact<AppRouter>();
 

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -15,10 +15,9 @@ const getQueryClient = () => {
   if (typeof window === "undefined") {
     // Server: always make a new query client
     return createQueryClient();
-  } else {
-    // Browser: use singleton pattern to keep the same query client
-    return (clientQueryClientSingleton ??= createQueryClient());
   }
+  // Browser: use singleton pattern to keep the same query client
+  return (clientQueryClientSingleton ??= createQueryClient());
 };
 
 export const api = createTRPCReact<AppRouter>();


### PR DESCRIPTION
Closes #1771

## Changelog

The way queryClient is initialized has been changed based on the following discussion within the Tanstack Query community: [discussion](https://github.com/TanStack/query/issues/6116)




