### PR TITLE
fix: Don't show planetscale serverless warning if not installing driver

### DIFF
--- a/.changeset/soft-stingrays-hammer.md
+++ b/.changeset/soft-stingrays-hammer.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Warning about planetscale's serverless driver now only shown if using mySQL

--- a/cli/src/helpers/logNextSteps.ts
+++ b/cli/src/helpers/logNextSteps.ts
@@ -69,7 +69,7 @@ export const logNextSteps = async ({
     );
   }
 
-  if (["mysql"].includes(databaseProvider)) {
+  if (databaseProvider === "planetscale") {
     logger.warn(
       `\nNote: We use the PlanetScale driver so that you can query your data in edge runtimes. If you want to use a different driver, you'll need to change it yourself.`
     );

--- a/cli/src/helpers/logNextSteps.ts
+++ b/cli/src/helpers/logNextSteps.ts
@@ -63,7 +63,7 @@ export const logNextSteps = async ({
     );
   }
 
-  if (packages?.drizzle.inUse) {
+  if (packages?.drizzle.inUse && !["mysql"].includes(databaseProvider) {
     logger.warn(
       `\nThank you for trying out the new Drizzle option. If you encounter any issues, please open an issue!`,
       `\nNote: We use the PlanetScale driver so that you can query your data in edge runtimes. If you want to use a different driver, you'll need to change it yourself.`

--- a/cli/src/helpers/logNextSteps.ts
+++ b/cli/src/helpers/logNextSteps.ts
@@ -63,9 +63,14 @@ export const logNextSteps = async ({
     );
   }
 
-  if (packages?.drizzle.inUse && !["mysql"].includes(databaseProvider) {
+  if (packages?.drizzle.inUse) {
     logger.warn(
-      `\nThank you for trying out the new Drizzle option. If you encounter any issues, please open an issue!`,
+      `\nThank you for trying out the new Drizzle option. If you encounter any issues, please open an issue!`
+    );
+  }
+
+  if (["mysql"].includes(databaseProvider)) {
+    logger.warn(
       `\nNote: We use the PlanetScale driver so that you can query your data in edge runtimes. If you want to use a different driver, you'll need to change it yourself.`
     );
   }


### PR DESCRIPTION
Closes #1776

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Updates `./cli/src/helpers/logNextSteps.ts` to only show planetscale error if using the mySQL driver

---

## Screenshots

Before:
<img width="1087" alt="image" src="https://github.com/t3-oss/create-t3-app/assets/29333568/72a14781-9212-4e0a-9b5f-e60df6f84605">
After:
<img width="963" alt="image" src="https://github.com/t3-oss/create-t3-app/assets/29333568/fb19632d-31d0-472c-9eae-e4eaf2f8bdd3">

If you are using mySQL you get:
<img width="1315" alt="image" src="https://github.com/t3-oss/create-t3-app/assets/29333568/86639889-a817-4704-bc28-6275b58fd3f8">



💯
