### PR TITLE
fix: create url safe db passwords

### DIFF
--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -35,7 +35,7 @@ if [ "$DB_PASSWORD" == "password" ]; then
     echo "Please set a password in the .env file and try again"
     exit 1
   fi
-  # Generate a random password URL-safe password
+  # Generate a random URL-safe password
   DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
   sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
 fi

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -35,7 +35,8 @@ if [ "$DB_PASSWORD" == "password" ]; then
     echo "Please set a password in the .env file and try again"
     exit 1
   fi
-  DB_PASSWORD=$(openssl rand -base64 12)
+  # Generate a random password URL-safe password
+  DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
   sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
 fi
 

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -35,7 +35,8 @@ if [ "$DB_PASSWORD" = "password" ]; then
     echo "Please set a password in the .env file and try again"
     exit 1
   fi
-  DB_PASSWORD=$(openssl rand -base64 12)
+  # Generate a random password URL-safe password
+  DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
   sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
 fi
 

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -35,7 +35,7 @@ if [ "$DB_PASSWORD" = "password" ]; then
     echo "Please set a password in the .env file and try again"
     exit 1
   fi
-  # Generate a random password URL-safe password
+  # Generate a random URL-safe password
   DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
   sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
 fi


### PR DESCRIPTION
Closes #1796<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

`openssl rand -base64 12` can create passwords with `+` and `/` characters which when used as database urls have to be encoded.
In this modification, I introduced `tr '+/' '-_'` immediately after the `openssl rand -base64 12` command to replace `+` with `-` and `/` with `_`, making the generated base64 string URL-safe. This ensures that the `DB_PASSWORD` variable will contain a URL-safe string that can be used directly in database URLs without further encoding.

---

## Screenshots

_[Screenshots]_

💯
