### PR TITLE
feat: apply drizzle lint rules to `db` keyword only

### DIFF
--- a/.changeset/violet-plums-sparkle.md
+++ b/.changeset/violet-plums-sparkle.md
@@ -1,5 +1,5 @@
 ---
-"create-t3-app": minor
+"create-t3-app": patch
 ---
 
 Apply drizzle-orm lint rules for `db` keyword only

--- a/.changeset/violet-plums-sparkle.md
+++ b/.changeset/violet-plums-sparkle.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Apply drizzle-orm lint rules for `db` keyword only

--- a/cli/src/installers/eslint.ts
+++ b/cli/src/installers/eslint.ts
@@ -30,11 +30,11 @@ const getEslintConfig = ({ usingDrizzle }: { usingDrizzle: boolean }) => {
       ...eslintConfig.rules,
       "drizzle/enforce-delete-with-where": [
         "error",
-        { drizzleObjectName: "db" },
+        { drizzleObjectName: ["db"] },
       ],
       "drizzle/enforce-update-with-where": [
         "error",
-        { drizzleObjectName: "db" },
+        { drizzleObjectName: ["db"] },
       ],
     };
   }

--- a/cli/src/installers/eslint.ts
+++ b/cli/src/installers/eslint.ts
@@ -28,8 +28,14 @@ const getEslintConfig = ({ usingDrizzle }: { usingDrizzle: boolean }) => {
 
     eslintConfig.rules = {
       ...eslintConfig.rules,
-      "drizzle/enforce-delete-with-where": "error",
-      "drizzle/enforce-update-with-where": "error",
+      "drizzle/enforce-delete-with-where": [
+        "error",
+        { drizzleObjectName: "db" },
+      ],
+      "drizzle/enforce-update-with-where": [
+        "error",
+        { drizzleObjectName: "db" },
+      ],
     };
   }
   return eslintConfig;


### PR DESCRIPTION
Closes #

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Apply drizzle-orm lint rules for specified keywords only (`db`)

---

## Screenshots

### Before
![image](https://github.com/t3-oss/create-t3-app/assets/38887390/d140da4d-eab0-4f53-98cb-ffbaf9df5b79)

### After
![image](https://github.com/t3-oss/create-t3-app/assets/38887390/86ba0787-d124-47d4-905b-e99fff7855c9)


💯
