### PR TITLE
fix: improve start-databse scripts exit and messages

### DIFF
--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -17,8 +17,13 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 if [ "$(docker ps -q -f name=$DB_CONTAINER_NAME)" ]; then
-  docker start $DB_CONTAINER_NAME
-  echo "Database container started"
+  echo "Database container '$DB_CONTAINER_NAME' already running"
+  exit 0
+fi
+
+if [ "$(docker ps -q -a -f name=$DB_CONTAINER_NAME)" ]; then
+  docker start "$DB_CONTAINER_NAME"
+  echo "Existing database container '$DB_CONTAINER_NAME' started"
   exit 0
 fi
 
@@ -40,6 +45,9 @@ if [ "$DB_PASSWORD" == "password" ]; then
   sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
 fi
 
-docker run --name $DB_CONTAINER_NAME -e MYSQL_ROOT_PASSWORD=$DB_PASSWORD -e MYSQL_DATABASE=project1 -d -p 3306:3306 docker.io/mysql
-
-echo "Database container was successfully created"
+docker run -d \
+  --name $DB_CONTAINER_NAME \
+  -e MYSQL_ROOT_PASSWORD="$DB_PASSWORD" \
+  -e MYSQL_DATABASE=project1 \
+  -p 3306:3306 \
+  docker.io/mysql && echo "Database container '$DB_CONTAINER_NAME' was successfully created"

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -12,7 +12,7 @@
 DB_CONTAINER_NAME="project1-mysql"
 
 if ! [ -x "$(command -v docker)" ]; then
-  echo "Docker is not installed. Please install docker and try again.\nDocker install guide: https://docs.docker.com/engine/install/"
+  echo -e "Docker is not installed. Please install docker and try again.\nDocker install guide: https://docs.docker.com/engine/install/"
   exit 1
 fi
 
@@ -31,7 +31,7 @@ fi
 set -a
 source .env
 
-DB_PASSWORD=$(echo $DATABASE_URL | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
+DB_PASSWORD=$(echo "$DATABASE_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 
 if [ "$DB_PASSWORD" == "password" ]; then
   echo "You are using the default database password"

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -17,8 +17,13 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 if [ "$(docker ps -q -f name=$DB_CONTAINER_NAME)" ]; then
-  docker start $DB_CONTAINER_NAME
-  echo "Database container started"
+  echo "Database container '$DB_CONTAINER_NAME' already running"
+  exit 0
+fi
+
+if [ "$(docker ps -q -a -f name=$DB_CONTAINER_NAME)" ]; then
+  docker start "$DB_CONTAINER_NAME"
+  echo "Existing database container '$DB_CONTAINER_NAME' started"
   exit 0
 fi
 
@@ -40,6 +45,9 @@ if [ "$DB_PASSWORD" = "password" ]; then
   sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
 fi
 
-docker run --name $DB_CONTAINER_NAME -e POSTGRES_PASSWORD=$DB_PASSWORD -e POSTGRES_DB=project1 -d -p 5432:5432 docker.io/postgres
-
-echo "Database container was successfully created"
+docker run -d \
+  --name $DB_CONTAINER_NAME \
+  -e POSTGRES_PASSWORD="$DB_PASSWORD" \
+  -e POSTGRES_DB=project1 \
+  -p 5432:5432 \
+  docker.io/postgres && echo "Database container '$DB_CONTAINER_NAME' was successfully created"

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -12,7 +12,7 @@
 DB_CONTAINER_NAME="project1-postgres"
 
 if ! [ -x "$(command -v docker)" ]; then
-  echo "Docker is not installed. Please install docker and try again.\nDocker install guide: https://docs.docker.com/engine/install/"
+  echo -e "Docker is not installed. Please install docker and try again.\nDocker install guide: https://docs.docker.com/engine/install/"
   exit 1
 fi
 
@@ -31,7 +31,7 @@ fi
 set -a
 source .env
 
-DB_PASSWORD=$(echo $DATABASE_URL | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
+DB_PASSWORD=$(echo "$DATABASE_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 
 if [ "$DB_PASSWORD" = "password" ]; then
   echo "You are using the default database password"


### PR DESCRIPTION

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Improve the exit status and messages of the docker start-database scripts. It could fail and still say "Database container was successfully created".
- Run [shellcheck](https://www.shellcheck.net/) on the scripts and accepted the minor suggestions

<details>

```
$ shellcheck postgres.sh 

In postgres.sh line 15:
  echo "Docker is not installed. Please install docker and try again.\nDocker install guide: https://docs.docker.com/engine/install/"
       ^-- SC2028 (info): echo may not expand escape sequences. Use printf.


In postgres.sh line 27:
source .env
       ^--^ SC1091 (info): Not following: .env was not specified as input (see shellcheck -x).


In postgres.sh line 29:
DB_PASSWORD=$(echo $DATABASE_URL | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
                   ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
DB_PASSWORD=$(echo "$DATABASE_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')


In postgres.sh line 43:
docker run --name $DB_CONTAINER_NAME -e POSTGRES_PASSWORD=$DB_PASSWORD -e POSTGRES_DB=project1 -d -p 5432:5432 docker.io/postgres
                                                          ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
docker run --name $DB_CONTAINER_NAME -e POSTGRES_PASSWORD="$DB_PASSWORD" -e POSTGRES_DB=project1 -d -p 5432:5432 docker.io/postgres

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: .env was not speci...
  https://www.shellcheck.net/wiki/SC2028 -- echo may not expand escape sequen...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  
```

</details>
