### PR TITLE
fix(env): change env variable name to be db type agnostic

### DIFF
--- a/cli/template/extras/src/env/with-auth-db-planetscale.js
+++ b/cli/template/extras/src/env/with-auth-db-planetscale.js
@@ -11,7 +11,7 @@ export const env = createEnv({
       .string()
       .url()
       .refine(
-        (str) => !str.includes("YOUR_MYSQL_URL_HERE"),
+        (str) => !str.includes("YOUR_DATABASE_URL_HERE"),
         "You forgot to change the default URL"
       ),
     NODE_ENV: z

--- a/cli/template/extras/src/env/with-db-planetscale.js
+++ b/cli/template/extras/src/env/with-db-planetscale.js
@@ -11,7 +11,7 @@ export const env = createEnv({
       .string()
       .url()
       .refine(
-        (str) => !str.includes("YOUR_MYSQL_URL_HERE"),
+        (str) => !str.includes("YOUR_DATABASE_URL_HERE"),
         "You forgot to change the default URL"
       ),
     NODE_ENV: z


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit (Assuming not necessary for a spelling change)

---

## Changelog

change from `YOUR_MYSQL_URL_HERE` => `YOUR_DATABASE_URL_HERE` to be db type agnostic in `env.js` files
