### PR TITLE
feat: expose trpc types to client for app router

### DIFF
--- a/.changeset/great-hornets-remain.md
+++ b/.changeset/great-hornets-remain.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Infers tRPC input & output types to the client for app router

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { loggerLink, unstable_httpBatchStreamLink } from "@trpc/client";
 import { createTRPCReact } from "@trpc/react-query";
+import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server";
 import { useState } from "react";
 import SuperJSON from "superjson";
 
@@ -21,6 +22,20 @@ const getQueryClient = () => {
 };
 
 export const api = createTRPCReact<AppRouter>();
+
+/**
+ * Inference helper for inputs.
+ *
+ * @example type HelloInput = RouterInputs['example']['hello']
+ */
+export type RouterInputs = inferRouterInputs<AppRouter>;
+
+/**
+ * Inference helper for outputs.
+ *
+ * @example type HelloOutput = RouterOutputs['example']['hello']
+ */
+export type RouterOutputs = inferRouterOutputs<AppRouter>;
 
 export function TRPCReactProvider(props: { children: React.ReactNode }) {
   const queryClient = getQueryClient();


### PR DESCRIPTION
I believe the correct place for this is in trpc/react.tsx to expose it to the client

Discord Questions about this:
https://discord.com/channels/966627436387266600/988912020558602331/1231632715493802085

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog
Exposes inferRouterInputs<AppRouter> & inferRouterOutputs<AppRouter> as RouterInputs & RouterOutputs to the client in the app router

---

## Screenshots
![Screenshot 2024-04-23 052125](https://github.com/t3-oss/create-t3-app/assets/43774713/c740af09-d11e-4c6d-a815-19f0eb79910e)

![Screenshot 2024-04-23 052333](https://github.com/t3-oss/create-t3-app/assets/43774713/422da6b4-d211-42fc-9538-210dde51476c)


💯
