### PR TITLE
fix: incorrect timestamps in drizzle

### DIFF
--- a/cli/template/extras/src/server/db/schema-drizzle/base-postgres.ts
+++ b/cli/template/extras/src/server/db/schema-drizzle/base-postgres.ts
@@ -23,10 +23,10 @@ export const posts = createTable(
   {
     id: serial("id").primaryKey(),
     name: varchar("name", { length: 256 }),
-    createdAt: timestamp("created_at")
+    createdAt: timestamp("created_at", { withTimezone: true })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
-    updatedAt: timestamp("updatedAt"),
+    updatedAt: timestamp("updatedAt", { withTimezone: true }),
   },
   (example) => ({
     nameIndex: index("name_idx").on(example.name),

--- a/cli/template/extras/src/server/db/schema-drizzle/with-auth-postgres.ts
+++ b/cli/template/extras/src/server/db/schema-drizzle/with-auth-postgres.ts
@@ -27,10 +27,10 @@ export const posts = createTable(
     createdById: varchar("createdById", { length: 255 })
       .notNull()
       .references(() => users.id),
-    createdAt: timestamp("created_at")
+    createdAt: timestamp("created_at", { withTimezone: true })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
-    updatedAt: timestamp("updatedAt"),
+    updatedAt: timestamp("updatedAt", { withTimezone: true }),
   },
   (example) => ({
     createdByIdIdx: index("createdById_idx").on(example.createdById),
@@ -44,6 +44,7 @@ export const users = createTable("user", {
   email: varchar("email", { length: 255 }).notNull(),
   emailVerified: timestamp("emailVerified", {
     mode: "date",
+    withTimezone: true,
   }).default(sql`CURRENT_TIMESTAMP`),
   image: varchar("image", { length: 255 }),
 });
@@ -92,7 +93,10 @@ export const sessions = createTable(
     userId: varchar("userId", { length: 255 })
       .notNull()
       .references(() => users.id),
-    expires: timestamp("expires", { mode: "date" }).notNull(),
+    expires: timestamp("expires", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
   },
   (session) => ({
     userIdIdx: index("session_userId_idx").on(session.userId),
@@ -108,7 +112,10 @@ export const verificationTokens = createTable(
   {
     identifier: varchar("identifier", { length: 255 }).notNull(),
     token: varchar("token", { length: 255 }).notNull(),
-    expires: timestamp("expires", { mode: "date" }).notNull(),
+    expires: timestamp("expires", {
+      mode: "date",
+      withTimezone: true,
+    }).notNull(),
   },
   (vt) => ({
     compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),


### PR DESCRIPTION
Closes #1863

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

added `withTimezone` option to all `timestamp()` calls in drizzle postgres. previously it was saving an incorrect timestamp, offset by -2h wrt UTC.

---

## Screenshots

![t3 drizzle fix](https://github.com/t3-oss/create-t3-app/assets/2622838/f57310d1-028b-4fda-b1ed-0ae93b731bb6)
