### PR TITLE
fix: updated --dbProvider CI flag to parse configured databases #1865

### DIFF
--- a/.changeset/big-ghosts-draw.md
+++ b/.changeset/big-ghosts-draw.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Parsed --dbprovider flag correctly and added related error message

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,11 +57,12 @@ jobs:
       # FIXME: this is a bit hacky, would rather have --packages=trpc,tailwind,... but not sure how to setup the matrix for that
       - run: cd cli && pnpm start ../../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }} --noGit --CI --trpc=${{ matrix.trpc }} --tailwind=${{ matrix.tailwind }} --nextAuth=${{ matrix.nextAuth }} --prisma=${{ matrix.prisma }} --drizzle=${{ matrix.drizzle }} --appRouter=${{ matrix.appRouter }} --dbProvider=${{ matrix.dbType }}
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
+        # can't use default mysql string cause t3-env blocks that
+      - run: sed -i 's/YOUR_MYSQL_URL_HERE/root:password@localhost:3306/g' .env >> .env
       - run: cd ../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }} && pnpm build
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
         env:
           NEXTAUTH_SECRET: foo
-          DATABASE_URL: mysql://root:root@localhost:3306/test # can't use url from example env cause we block that in t3-env
           DISCORD_CLIENT_ID: bar
           DISCORD_CLIENT_SECRET: baz
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,13 +58,13 @@ jobs:
       - run: cd cli && pnpm start ../../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }} --noGit --CI --trpc=${{ matrix.trpc }} --tailwind=${{ matrix.tailwind }} --nextAuth=${{ matrix.nextAuth }} --prisma=${{ matrix.prisma }} --drizzle=${{ matrix.drizzle }} --appRouter=${{ matrix.appRouter }} --dbProvider=${{ matrix.dbType }}
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
         # can't use default mysql string cause t3-env blocks that
-      - run: sed -i 's/YOUR_MYSQL_URL_HERE/root:password@localhost:3306/g' ../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }}/.env >> ../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }}/.env
       - run: cd ../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }} && pnpm build
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
         env:
           NEXTAUTH_SECRET: foo
           DISCORD_CLIENT_ID: bar
           DISCORD_CLIENT_SECRET: baz
+          SKIP_ENV_VALIDATION: true
 
   build-t3-app-with-bun:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
       - run: cd cli && pnpm start ../../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }} --noGit --CI --trpc=${{ matrix.trpc }} --tailwind=${{ matrix.tailwind }} --nextAuth=${{ matrix.nextAuth }} --prisma=${{ matrix.prisma }} --drizzle=${{ matrix.drizzle }} --appRouter=${{ matrix.appRouter }} --dbProvider=${{ matrix.dbType }}
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
         # can't use default mysql string cause t3-env blocks that
-      - run: sed -i 's/YOUR_MYSQL_URL_HERE/root:password@localhost:3306/g' .env >> .env
+      - run: sed -i 's/YOUR_MYSQL_URL_HERE/root:password@localhost:3306/g' ../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }}/.env >> ../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }}/.env
       - run: cd ../ci-${{ matrix.trpc }}-${{ matrix.tailwind }}-${{ matrix.nextAuth }}-${{ matrix.prisma }}-${{ matrix.drizzle}}-${{ matrix.appRouter }}-${{ matrix.dbType }} && pnpm build
         if: ${{ steps.matrix-valid.outputs.continue == 'true' }}
         env:

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -197,9 +197,14 @@ export const runCli = async (): Promise<CliResults> => {
       process.exit(0);
     }
 
-    cliResults.databaseProvider = cliResults.packages.includes("drizzle")
-      ? cliResults.flags.dbProvider
-      : "sqlite";
+    if (
+      cliResults.packages.includes("drizzle") ||
+      cliResults.packages.includes("prisma")
+    ) {
+      cliResults.databaseProvider = cliResults.flags.dbProvider ?? "sqlite";
+    } else {
+      cliResults.databaseProvider = "sqlite";
+    }
 
     return cliResults;
   }

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -138,7 +138,7 @@ export const runCli = async (): Promise<CliResults> => {
       `Choose a database provider to use. Possible values: ${databaseProviders.join(
         ", "
       )}`,
-      defaultOptions.flags.importAlias
+      defaultOptions.flags.dbProvider
     )
     .option(
       "--appRouter [boolean]",

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -197,14 +197,11 @@ export const runCli = async (): Promise<CliResults> => {
       process.exit(0);
     }
 
-    if (
+    cliResults.databaseProvider =
       cliResults.packages.includes("drizzle") ||
       cliResults.packages.includes("prisma")
-    ) {
-      cliResults.databaseProvider = cliResults.flags.dbProvider ?? "sqlite";
-    } else {
-      cliResults.databaseProvider = "sqlite";
-    }
+        ? cliResults.flags.dbProvider
+        : "sqlite";
 
     return cliResults;
   }

--- a/www/src/pages/en/installation.mdx
+++ b/www/src/pages/en/installation.mdx
@@ -49,13 +49,15 @@ After your app has been scaffolded, check out the [first steps](/en/usage/first-
 
 For our CI, we have some experimental flags that allow you to scaffold any app without any prompts. If this use case applies to you, you can use these flags. Please note that these flags are experimental and may change in the future without following semver versioning.
 
-| Flag         | Description                         |
-| ------------ | ----------------------------------- |
-| `--CI`       | Let the CLI know you're in CI mode  |
-| `--trpc`     | Include tRPC in the project         |
-| `--prisma`   | Include Prisma in the project       |
-| `--nextAuth` | Include NextAuth.js in the project  |
-| `--tailwind` | Include Tailwind CSS in the project |
+| Flag                      | Description                                  |
+| ------------------------- | -------------------------------------------- |
+| `--CI`                    | Let the CLI know you're in CI mode           |
+| `--trpc`                  | Include tRPC in the project                  |
+| `--prisma`                | Include Prisma in the project                |
+| `--drizzle`               | Inlcude Drizzle in the project               |
+| `--nextAuth`              | Include NextAuth.js in the project           |
+| `--tailwind`              | Include Tailwind CSS in the project          |
+| `--dbProvider [provider]` | Include a configured database in the project |
 
 <Callout type="warning">
   If you don't provide the `CI` flag, the rest of these flags have no effect.
@@ -63,10 +65,18 @@ For our CI, we have some experimental flags that allow you to scaffold any app w
 
 You don't need to explicitly opt-out of the packages you don't want. However, if you prefer to be explicit, you can pass `false`, e.g. `--nextAuth false`.
 
+The --dbProvider command has 4 database values to choose from: mysql, postgres, planetscale, sqlite. If the command is not provided the default value will be sqlite.
+
 ### Example
 
 The following would scaffold a T3 App with tRPC and Tailwind CSS.
 
 ```bash
 pnpm dlx create-t3-app@latest --CI --trpc --tailwind
+```
+
+The following would scaffold a T3 App with NextAuth.js, Tailwind CSS, Drizzle, and PostgreSQL.
+
+```bash
+pnpm dlx create-t3-app@latest --CI --nextAuth --tailwind --drizzle --dbProvider postgres
 ```


### PR DESCRIPTION
Closes #1865

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Inside [cli/src/cli/index.ts](https://github.com/t3-oss/create-t3-app/blob/main/cli/src/cli/index.ts)

Updated CI flags to include dbProvider with a default value of 'sqlite'
Updated default value of --dbProvider
Included an error check for the input of the --dbProvider value
Set cliResults.databaseProvider to a conditional value based on the user input
Included parser for both Drizzle and Prisma

Updated documentation to include CLI flags and examples

Feedback or advice is encouraged 💯 

💯
