### PR TITLE
feat: add vscode installer

### DIFF
--- a/.changeset/few-cougars-live.md
+++ b/.changeset/few-cougars-live.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Use custom editor labels for pages, layouts and API routes.

--- a/.changeset/thin-birds-brush.md
+++ b/.changeset/thin-birds-brush.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+Use the workspace typescript version by default so you get Next.js specific typesafety!

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -7,6 +7,7 @@ import { type PackageManager } from "~/utils/getUserPkgManager.js";
 import { dbContainerInstaller } from "./dbContainer.js";
 import { drizzleInstaller } from "./drizzle.js";
 import { dynamicEslintInstaller } from "./eslint.js";
+import { vscodeInstaller } from "./vscode.js";
 
 // Turning this into a const allows the list to be iterated over for programatically creating prompt options
 // Should increase extensability in the future
@@ -19,6 +20,7 @@ export const availablePackages = [
   "envVariables",
   "eslint",
   "dbContainer",
+  "vscode",
 ] as const;
 export type AvailablePackages = (typeof availablePackages)[number];
 
@@ -85,5 +87,9 @@ export const buildPkgInstallerMap = (
   eslint: {
     inUse: true,
     installer: dynamicEslintInstaller,
+  },
+  vscode: {
+    inUse: true,
+    installer: vscodeInstaller,
   },
 });

--- a/cli/src/installers/vscode.ts
+++ b/cli/src/installers/vscode.ts
@@ -1,0 +1,13 @@
+import path from "path";
+import fs from "fs-extra";
+
+import { type Installer } from "~/installers/index.js";
+
+const _vscodeSettingsPath = path.resolve(
+  __dirname,
+  "../../template/extras/config/.vscode"
+);
+
+export const vscodeInstaller: Installer = ({ projectDir }) => {
+  fs.moveSync(_vscodeSettingsPath, path.join(projectDir, ".vscode"));
+};

--- a/cli/src/installers/vscode.ts
+++ b/cli/src/installers/vscode.ts
@@ -1,13 +1,7 @@
-import path from "path";
 import fs from "fs-extra";
 
 import { type Installer } from "~/installers/index.js";
 
-const _vscodeSettingsPath = path.resolve(
-  __dirname,
-  "../../template/extras/config/.vscode"
-);
-
 export const vscodeInstaller: Installer = ({ projectDir }) => {
-  fs.moveSync(_vscodeSettingsPath, path.join(projectDir, ".vscode"));
+  fs.copySync("cli/template/extras/config/.vscode", projectDir + "/.vscode");
 };

--- a/cli/template/extras/config/.vscode/settings.json
+++ b/cli/template/extras/config/.vscode/settings.json
@@ -13,9 +13,8 @@
    * Next.js
    */
   "workbench.editor.customLabels.patterns": {
-    "**src/app/**/page.tsx": "${dirname} - Page",
-    "**src/app/**/layout.tsx": "${dirname} - Layout",
-    "**src/app/**/route.ts": "${dirname} - API",
-    "**src/app/**/route.tsx": "${dirname} - API"
+    "**/src/app/**/page.tsx": "${dirname} - Page",
+    "**/src/app/**/layout.tsx": "${dirname} - Layout",
+    "**/src/app/**/route.{ts,tsx}": "${dirname} - API"
   }
 }

--- a/cli/template/extras/config/.vscode/settings.json
+++ b/cli/template/extras/config/.vscode/settings.json
@@ -12,6 +12,7 @@
    * Custom editor labels Makes it easy to distinguish between pages, layouts and API routes in
    * Next.js
    */
+  "workbench.editor.customLabels.enabled": true,
   "workbench.editor.customLabels.patterns": {
     "**/src/app/**/page.tsx": "${dirname} - Page",
     "**/src/app/**/layout.tsx": "${dirname} - Layout",

--- a/cli/template/extras/config/.vscode/settings.json
+++ b/cli/template/extras/config/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  /**
+   * Makes sure you're using the TypeScript plugin that comes with Next.js
+   *
+   * @see
+   * https://nextjs.org/docs/app/building-your-application/configuring/typescript#typescript-plugin
+   */
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+
+  /**
+   * Custom editor labels Makes it easy to distinguish between pages, layouts and API routes in
+   * Next.js
+   */
+  "workbench.editor.customLabels.patterns": {
+    "**src/app/**/page.tsx": "${dirname} - Page",
+    "**src/app/**/layout.tsx": "${dirname} - Layout",
+    "**src/app/**/route.ts": "${dirname} - API",
+    "**src/app/**/route.tsx": "${dirname} - API"
+  }
+}

--- a/cli/template/extras/config/.vscode/settings.json
+++ b/cli/template/extras/config/.vscode/settings.json
@@ -6,7 +6,6 @@
    * https://nextjs.org/docs/app/building-your-application/configuring/typescript#typescript-plugin
    */
   "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
 
   /**
    * Custom editor labels Makes it easy to distinguish between pages, layouts and API routes in


### PR DESCRIPTION
Closes #1852 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

1. Add a installer for vscode, along with some handy settings for Next.js:
   - Use custom editor labels for `page`s, `layout`s and API `route`s.
   - Uses the project-specific typescript version by default, so it can use the [TypeScript Plugin for Next.js](https://nextjs.org/docs/app/building-your-application/configuring/typescript#typescript-plugin)

---

## Screenshots

### Before
![image](https://github.com/t3-oss/create-t3-app/assets/38887390/216670f7-c388-4c0f-913f-6d32adf68c58)

### After
![image](https://github.com/t3-oss/create-t3-app/assets/38887390/4eef9a66-af05-4a28-a168-38e748afa09e)

💯
