### PR TITLE
fix: start-database.sh CONTAINER_NAME update with '.' project name (#1834)

### DIFF
--- a/.changeset/selfish-geese-camp.md
+++ b/.changeset/selfish-geese-camp.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fixed project creation of . bug in ./start-database.sh

--- a/cli/src/installers/dbContainer.ts
+++ b/cli/src/installers/dbContainer.ts
@@ -3,6 +3,7 @@ import path from "path";
 
 import { PKG_ROOT } from "~/consts.js";
 import { type Installer } from "~/installers/index.js";
+import { parseNameAndPath } from "~/utils/parseNameAndPath.js";
 
 export const dbContainerInstaller: Installer = ({
   projectDir,
@@ -15,6 +16,13 @@ export const dbContainerInstaller: Installer = ({
   );
   const scriptText = fs.readFileSync(scriptSrc, "utf-8");
   const scriptDest = path.join(projectDir, "start-database.sh");
-  fs.writeFileSync(scriptDest, scriptText.replaceAll("project1", projectName));
+  // for configuration with postgresql and mysql when project is created with '.' project name
+  const [projectNameParsed] =
+    projectName == "." ? parseNameAndPath(projectDir) : [projectName];
+
+  fs.writeFileSync(
+    scriptDest,
+    scriptText.replaceAll("project1", projectNameParsed)
+  );
   fs.chmodSync(scriptDest, "755");
 };


### PR DESCRIPTION
Closes #1834

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

NOTE: I was messing with my forked repo and accidentally closed the original [pr](https://github.com/t3-oss/create-t3-app/pull/1857) because of a rebase of the main branch.

The dbContainer.ts file in cli/src/installers/dbContainer.ts was updated with a parseNameAndPath function when a projectName of "." was used. This was done with a ternary and destructuring to keep the type safety of the variable.

I had a few options.  
1. I could change the start-database.sh script to check for "." project names and change accordingly
2. I could change the file that was changing the start-database.sh file
I decided to go with the last route because it's a single source of truth and can be used for future implementations.

I followed the data flow of projectName and scopedProjectName through and through and couldn't find a solution.
Then I tried a few other things to see If I could make this feel less hacky but to no avail.

## Screenshots

_[Screenshots]_

💯
