### PR TITLE
fix(with-auth.prisma): add missing field refresh_token_expires_in

### DIFF
--- a/cli/template/extras/prisma/schema/with-auth.prisma
+++ b/cli/template/extras/prisma/schema/with-auth.prisma
@@ -28,19 +28,20 @@ model Post {
 
 // Necessary for Next auth
 model Account {
-    id                String  @id @default(cuid())
-    userId            String
-    type              String
-    provider          String
-    providerAccountId String
-    refresh_token     String? // @db.Text
-    access_token      String? // @db.Text
-    expires_at        Int?
-    token_type        String?
-    scope             String?
-    id_token          String? // @db.Text
-    session_state     String?
-    user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+    id                       String  @id @default(cuid())
+    userId                   String
+    type                     String
+    provider                 String
+    providerAccountId        String
+    refresh_token            String? // @db.Text
+    access_token             String? // @db.Text
+    expires_at               Int?
+    token_type               String?
+    scope                    String?
+    id_token                 String? // @db.Text
+    session_state            String?
+    user                     User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+    refresh_token_expires_in Int?
 
     @@unique([provider, providerAccountId])
 }


### PR DESCRIPTION
With the default config, trying to use `GithubProvider`, I found the error "Try signing in with a different account".
There was one missing field `refresh_token_expires_in` when `next-auth` tried to create a record `Account`. Should be fixed now.