### PR TITLE
fix: remove deprecated push command in drizzle package.json scripts (…

### DIFF
--- a/.changeset/thirty-tables-tie.md
+++ b/.changeset/thirty-tables-tie.md
@@ -1,0 +1,6 @@
+---
+"create-t3-app": patch
+---
+
+fix: remove deprecated push command in drizzle package.json scripts (…
+)

--- a/cli/src/installers/drizzle.ts
+++ b/cli/src/installers/drizzle.ts
@@ -83,14 +83,7 @@ export const drizzleInstaller: Installer = ({
   const packageJsonContent = fs.readJSONSync(packageJsonPath) as PackageJson;
   packageJsonContent.scripts = {
     ...packageJsonContent.scripts,
-    "db:push": `drizzle-kit push:${
-      {
-        postgres: "pg",
-        sqlite: "sqlite",
-        mysql: "mysql",
-        planetscale: "mysql",
-      }[databaseProvider]
-    }`,
+    "db:push": `drizzle-kit push`,
     "db:studio": "drizzle-kit studio",
   };
 


### PR DESCRIPTION
…#1883)

Closes #1883

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Removed the deprecated command in drizzle cli installer which was deprecated in drizzle-kit@0.21.0

---

