### PR TITLE
fix: Fixes drizzle db push command

### DIFF
--- a/cli/src/installers/drizzle.ts
+++ b/cli/src/installers/drizzle.ts
@@ -83,14 +83,7 @@ export const drizzleInstaller: Installer = ({
   const packageJsonContent = fs.readJSONSync(packageJsonPath) as PackageJson;
   packageJsonContent.scripts = {
     ...packageJsonContent.scripts,
-    "db:push": `drizzle-kit push:${
-      {
-        postgres: "pg",
-        sqlite: "sqlite",
-        mysql: "mysql",
-        planetscale: "mysql",
-      }[databaseProvider]
-    }`,
+    "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
   };
 


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- Drizzle Kit 0.21.0 has dropped the dialect from the drizzle-kit push command https://orm.drizzle.team/kit-docs/upgrade-21#how-to-migrate-to-0210
- Updated cli/src/installers/drizzle.ts to reflect this change




💯
