### PR TITLE
patch: apply drizzle eslint rules to `ctx.db`

### DIFF
--- a/.changeset/seven-mice-begin.md
+++ b/.changeset/seven-mice-begin.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Apply Drizzle ORM ESLint Rules to `ctx.db` object that is available in tRPC.

--- a/cli/src/installers/eslint.ts
+++ b/cli/src/installers/eslint.ts
@@ -30,11 +30,11 @@ const getEslintConfig = ({ usingDrizzle }: { usingDrizzle: boolean }) => {
       ...eslintConfig.rules,
       "drizzle/enforce-delete-with-where": [
         "error",
-        { drizzleObjectName: ["db"] },
+        { drizzleObjectName: ["db", "ctx.db"] },
       ],
       "drizzle/enforce-update-with-where": [
         "error",
-        { drizzleObjectName: ["db"] },
+        { drizzleObjectName: ["db", "ctx.db"] },
       ],
     };
   }

--- a/cli/src/installers/index.ts
+++ b/cli/src/installers/index.ts
@@ -7,6 +7,7 @@ import { type PackageManager } from "~/utils/getUserPkgManager.js";
 import { dbContainerInstaller } from "./dbContainer.js";
 import { drizzleInstaller } from "./drizzle.js";
 import { dynamicEslintInstaller } from "./eslint.js";
+import { vscodeInstaller } from "./vscode.js";
 
 // Turning this into a const allows the list to be iterated over for programatically creating prompt options
 // Should increase extensability in the future
@@ -19,6 +20,7 @@ export const availablePackages = [
   "envVariables",
   "eslint",
   "dbContainer",
+  "vscode",
 ] as const;
 export type AvailablePackages = (typeof availablePackages)[number];
 
@@ -85,5 +87,9 @@ export const buildPkgInstallerMap = (
   eslint: {
     inUse: true,
     installer: dynamicEslintInstaller,
+  },
+  vscode: {
+    inUse: true,
+    installer: vscodeInstaller,
   },
 });

--- a/cli/src/installers/vscode.ts
+++ b/cli/src/installers/vscode.ts
@@ -1,0 +1,13 @@
+import path from "path";
+import fs from "fs-extra";
+
+import { type Installer } from "~/installers/index.js";
+
+const _vscodeSettingsPath = path.resolve(
+  __dirname,
+  "../../template/extras/config/.vscode"
+);
+
+export const vscodeInstaller: Installer = ({ projectDir }) => {
+  fs.moveSync(_vscodeSettingsPath, path.join(projectDir, ".vscode"));
+};

--- a/cli/template/extras/config/.vscode/settings.json
+++ b/cli/template/extras/config/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  /**
+   * Makes sure you're using the TypeScript plugin that comes with Next.js
+   *
+   * @see
+   * https://nextjs.org/docs/app/building-your-application/configuring/typescript#typescript-plugin
+   */
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+
+  /**
+   * Custom editor labels Makes it easy to distinguish between pages, layouts and API routes in
+   * Next.js
+   */
+  "workbench.editor.customLabels.patterns": {
+    "**src/app/**/page.tsx": "${dirname} - Page",
+    "**src/app/**/layout.tsx": "${dirname} - Layout",
+    "**src/app/**/route.ts": "${dirname} - API",
+    "**src/app/**/route.tsx": "${dirname} - API"
+  }
+}


### PR DESCRIPTION
Closes #

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Add `ctx.db` to the `drizzleObjectName` list for the drizzle eslint rules to be applied when using `ctx.db` in trpc routes.

Previously, it would only apply if you `import { db } from "@/db"`

---

## Screenshots

_[Screenshots]_

💯
