### PR TITLE
patch: apply drizzle eslint rules to `ctx.db`

### DIFF
--- a/.changeset/dirty-snakes-rescue.md
+++ b/.changeset/dirty-snakes-rescue.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Apply drizzle rules for `ctx.db` object in tRPC context

--- a/cli/src/installers/eslint.ts
+++ b/cli/src/installers/eslint.ts
@@ -30,11 +30,11 @@ const getEslintConfig = ({ usingDrizzle }: { usingDrizzle: boolean }) => {
       ...eslintConfig.rules,
       "drizzle/enforce-delete-with-where": [
         "error",
-        { drizzleObjectName: ["db"] },
+        { drizzleObjectName: ["db", "ctx.db"] },
       ],
       "drizzle/enforce-update-with-where": [
         "error",
-        { drizzleObjectName: ["db"] },
+        { drizzleObjectName: ["db", "ctx.db"] },
       ],
     };
   }


### PR DESCRIPTION
Closes #

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Add `ctx.db` to the `drizzleObjectName` list for the drizzle eslint rules to be applied when using `ctx.db` in trpc routes.

Previously, it would only apply if you `import { db } from "@/db"`

---

## Screenshots

![image](https://github.com/t3-oss/create-t3-app/assets/38887390/d2f0a48a-bc74-40d9-92bb-df66d68fbc4c)

💯
