### PR TITLE
fix: tailwind selector strategy changed in 3.4.1

### DIFF
--- a/upgrade/tailwind.config.ts
+++ b/upgrade/tailwind.config.ts
@@ -2,7 +2,7 @@ import { type Config } from "tailwindcss";
 import { fontFamily } from "tailwindcss/defaultTheme";
 
 export default {
-  darkMode: ["class"],
+  darkMode: ["selector"],
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     container: {

--- a/www/tailwind.config.ts
+++ b/www/tailwind.config.ts
@@ -3,7 +3,7 @@ import { type Config } from "tailwindcss";
 
 export default {
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
-  darkMode: "class",
+  darkMode: "selector",
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Update selector strategy in both `tailwind.config.ts` files.

---

## Supporting Documentation

https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
