### PR TITLE
docs: fix corepack issues with using yarn as default

### DIFF
--- a/www/src/pages/en/deployment/docker.md
+++ b/www/src/pages/en/deployment/docker.md
@@ -77,7 +77,7 @@ COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml\* ./
 RUN \
     if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
     elif [ -f package-lock.json ]; then npm ci; \
-    elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && pnpm i; \
+    elif [ -f pnpm-lock.yaml ]; then npm install -g pnpm && pnpm i; \
     else echo "Lockfile not found." && exit 1; \
     fi
 
@@ -95,7 +95,7 @@ COPY . .
 RUN \
     if [ -f yarn.lock ]; then SKIP_ENV_VALIDATION=1 yarn build; \
     elif [ -f package-lock.json ]; then SKIP_ENV_VALIDATION=1 npm run build; \
-    elif [ -f pnpm-lock.yaml ]; then yarn global add pnpm && SKIP_ENV_VALIDATION=1 pnpm run build; \
+    elif [ -f pnpm-lock.yaml ]; then npm install -g pnpm && SKIP_ENV_VALIDATION=1 pnpm run build; \
     else echo "Lockfile not found." && exit 1; \
     fi
 


### PR DESCRIPTION
Closes #na

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

An issue is encountered when building the dockerfile and pnpm is the chosen engine - this is due to corepack checks.

Switched from using yarn for installing pnpm.

Issue is repeatable by running `docker build -t test . --pull` from the root of the repo.

Thanks for the awesome project!