### PR TITLE
docs:Update the link to the latest trpc Docs

### DIFF
--- a/www/.astro/settings.json
+++ b/www/.astro/settings.json
@@ -1,5 +1,0 @@
-{
-  "_variables": {
-    "lastUpdateCheck": 1721215609145
-  }
-}

--- a/www/.astro/settings.json
+++ b/www/.astro/settings.json
@@ -1,5 +1,5 @@
 {
-	"_variables": {
-		"lastUpdateCheck": 1721215609145
-	}
+  "_variables": {
+    "lastUpdateCheck": 1721215609145
+  }
 }

--- a/www/.astro/settings.json
+++ b/www/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1721215609145
+	}
+}

--- a/www/src/pages/en/usage/trpc.md
+++ b/www/src/pages/en/usage/trpc.md
@@ -298,7 +298,7 @@ export default handler;
 
 ### Optimistic updates
 
-Optimistic updates are when we update the UI before the API call has finished. This gives the user a better experience because they don't have to wait for the API call to finish before the UI reflects the result of their action. However, apps that value data correctness highly should avoid optimistic updates as they are not a "true" representation of backend state. You can read more on the [React Query docs](https://tanstack.com/query/v4/docs/guides/optimistic-updates).
+Optimistic updates are when we update the UI before the API call has finished. This gives the user a better experience because they don't have to wait for the API call to finish before the UI reflects the result of their action. However, apps that value data correctness highly should avoid optimistic updates as they are not a "true" representation of backend state. You can read more on the [React Query docs](https://tanstack.com/query/latest/docs).
 
 ```tsx
 const MyComponent = () => {
@@ -375,8 +375,8 @@ test("protected example router", async () => {
 
 ## Useful Resources
 
-| Resource               | Link                                                    |
-| ---------------------- | ------------------------------------------------------- |
-| tRPC Docs              | https://www.trpc.io                                     |
-| Bunch of tRPC Examples | https://github.com/trpc/trpc/tree/next/examples         |
-| React Query Docs       | https://tanstack.com/query/v4/docs/adapters/react-query |
+| Resource               | Link                                            |
+| ---------------------- | ----------------------------------------------- |
+| tRPC Docs              | https://www.trpc.io                             |
+| Bunch of tRPC Examples | https://github.com/trpc/trpc/tree/next/examples |
+| React Query Docs       | https://tanstack.com/query/latest/docs          |

--- a/www/src/pages/en/usage/trpc.md
+++ b/www/src/pages/en/usage/trpc.md
@@ -298,7 +298,7 @@ export default handler;
 
 ### Optimistic updates
 
-Optimistic updates are when we update the UI before the API call has finished. This gives the user a better experience because they don't have to wait for the API call to finish before the UI reflects the result of their action. However, apps that value data correctness highly should avoid optimistic updates as they are not a "true" representation of backend state. You can read more on the [React Query docs](https://tanstack.com/query/latest/docs).
+Optimistic updates are when we update the UI before the API call has finished. This gives the user a better experience because they don't have to wait for the API call to finish before the UI reflects the result of their action. However, apps that value data correctness highly should avoid optimistic updates as they are not a "true" representation of backend state. You can read more on the [React Query docs](https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates).
 
 ```tsx
 const MyComponent = () => {


### PR DESCRIPTION
Update the reference link of React Query Docs in t3 tRPC usage documentation.

closes #1923

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Change the latest tRPC docs link

---

## Screenshots

![image](https://github.com/user-attachments/assets/08f144b2-4677-4428-9fe1-e904b61a3b46)


💯
