### PR TITLE
fix: `getLatest` procedure has unresolved promise before null coalescing

### DIFF
--- a/.changeset/soft-garlics-rush.md
+++ b/.changeset/soft-garlics-rush.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fix unresolved promise before null coalescing

--- a/cli/template/extras/src/server/api/routers/post/with-auth-drizzle.ts
+++ b/cli/template/extras/src/server/api/routers/post/with-auth-drizzle.ts
@@ -28,12 +28,12 @@ export const postRouter = createTRPCRouter({
       });
     }),
 
-  getLatest: publicProcedure.query(({ ctx }) => {
-    const post = ctx.db.query.posts.findFirst({
-      orderBy: (posts, { desc }) => [desc(posts.createdAt)],
-    });
-
-    return post ?? null;
+  getLatest: publicProcedure.query(async ({ ctx }) => {
+    return ctx.db.query.posts
+      .findFirst({
+        orderBy: (posts, { desc }) => [desc(posts.createdAt)],
+      })
+      .then((post) => post ?? null);
   }),
 
   getSecretMessage: protectedProcedure.query(() => {

--- a/cli/template/extras/src/server/api/routers/post/with-auth-prisma.ts
+++ b/cli/template/extras/src/server/api/routers/post/with-auth-prisma.ts
@@ -30,12 +30,10 @@ export const postRouter = createTRPCRouter({
     }),
 
   getLatest: protectedProcedure.query(({ ctx }) => {
-    const post = ctx.db.post.findFirst({
+    return ctx.db.post.findFirst({
       orderBy: { createdAt: "desc" },
       where: { createdBy: { id: ctx.session.user.id } },
     });
-
-    return post ?? null;
   }),
 
   getSecretMessage: protectedProcedure.query(() => {

--- a/cli/template/extras/src/server/api/routers/post/with-drizzle.ts
+++ b/cli/template/extras/src/server/api/routers/post/with-drizzle.ts
@@ -23,11 +23,11 @@ export const postRouter = createTRPCRouter({
       });
     }),
 
-  getLatest: publicProcedure.query(({ ctx }) => {
-    const post = ctx.db.query.posts.findFirst({
-      orderBy: (posts, { desc }) => [desc(posts.createdAt)],
-    });
-
-    return post ?? null;
+  getLatest: publicProcedure.query(async ({ ctx }) => {
+    return ctx.db.query.posts
+      .findFirst({
+        orderBy: (posts, { desc }) => [desc(posts.createdAt)],
+      })
+      .then((post) => post ?? null);
   }),
 });

--- a/cli/template/extras/src/server/api/routers/post/with-prisma.ts
+++ b/cli/template/extras/src/server/api/routers/post/with-prisma.ts
@@ -25,10 +25,8 @@ export const postRouter = createTRPCRouter({
     }),
 
   getLatest: publicProcedure.query(({ ctx }) => {
-    const post = ctx.db.post.findFirst({
+    return ctx.db.post.findFirst({
       orderBy: { createdAt: "desc" },
     });
-
-    return post ?? null;
   }),
 });


### PR DESCRIPTION
Closes #1943

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Promise now resolves in drizzle templates before null coalescing.
Removed unnecessary null coalescing in prisma templates, they already return null

---

## Screenshots

_[Screenshots]_

💯
