### PR TITLE
Align all templates to use publicProcedure for `getLatest` method

### DIFF
--- a/cli/template/extras/src/server/api/routers/post/with-auth-prisma.ts
+++ b/cli/template/extras/src/server/api/routers/post/with-auth-prisma.ts
@@ -26,7 +26,7 @@ export const postRouter = createTRPCRouter({
       });
     }),
 
-  getLatest: protectedProcedure.query(async ({ ctx }) => {
+  getLatest: publicProcedure.query(async ({ ctx }) => {
     const post = await ctx.db.post.findFirst({
       orderBy: { createdAt: "desc" },
       where: { createdBy: { id: ctx.session.user.id } },

--- a/cli/template/extras/src/server/api/routers/post/with-auth.ts
+++ b/cli/template/extras/src/server/api/routers/post/with-auth.ts
@@ -27,7 +27,7 @@ export const postRouter = createTRPCRouter({
       return post;
     }),
 
-  getLatest: protectedProcedure.query(() => {
+  getLatest: publicProcedure.query(() => {
     return post;
   }),
 


### PR DESCRIPTION
Fixes #1961

Fix the issue with errors on a fresh T3 app install by changing `getLatest` to use `publicProcedure` instead of `protectedProcedure`.

* **cli/template/extras/src/server/api/routers/post/with-auth.ts**
  - Change `getLatest` to use `publicProcedure` instead of `protectedProcedure`.
* **cli/template/extras/src/server/api/routers/post/with-auth-prisma.ts**
  - Change `getLatest` to use `publicProcedure` instead of `protectedProcedure`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/t3-oss/create-t3-app/issues/1961?shareId=d824e79b-03c5-4912-bf49-5883353477ef).