### PR TITLE
fix: conditional prefetch for protectedProcedure in auth templates

### DIFF
--- a/.changeset/lucky-parents-invent.md
+++ b/.changeset/lucky-parents-invent.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix issue with prefetch protected procedure in auth templates

--- a/cli/template/extras/src/app/page/with-auth-trpc-tw.tsx
+++ b/cli/template/extras/src/app/page/with-auth-trpc-tw.tsx
@@ -8,7 +8,9 @@ export default async function Home() {
   const hello = await api.post.hello({ text: "from tRPC" });
   const session = await getServerAuthSession();
 
-  void api.post.getLatest.prefetch();
+  if (session?.user) {
+    void api.post.getLatest.prefetch();
+  }
 
   return (
     <HydrateClient>

--- a/cli/template/extras/src/app/page/with-auth-trpc.tsx
+++ b/cli/template/extras/src/app/page/with-auth-trpc.tsx
@@ -9,7 +9,9 @@ export default async function Home() {
   const hello = await api.post.hello({ text: "from tRPC" });
   const session = await getServerAuthSession();
 
-  void api.post.getLatest.prefetch();
+  if (session?.user) {
+    void api.post.getLatest.prefetch();
+  }
 
   return (
     <HydrateClient>

--- a/cli/template/extras/src/server/api/routers/post/with-auth-drizzle.ts
+++ b/cli/template/extras/src/server/api/routers/post/with-auth-drizzle.ts
@@ -25,7 +25,7 @@ export const postRouter = createTRPCRouter({
       });
     }),
 
-  getLatest: publicProcedure.query(async ({ ctx }) => {
+  getLatest: protectedProcedure.query(async ({ ctx }) => {
     const post = await ctx.db.query.posts.findFirst({
       orderBy: (posts, { desc }) => [desc(posts.createdAt)],
     });


### PR DESCRIPTION
Fixes #1961

Add condition to prefetch `getLatest` only if the user is authenticated.
Align all auth templates to use `protectedProcedure` for `getLatest` method.
