### PR TITLE
fix: github stars count

### DIFF
--- a/www/.astro/settings.json
+++ b/www/.astro/settings.json
@@ -1,5 +1,0 @@
-{
-	"_variables": {
-		"lastUpdateCheck": 1724129638164
-	}
-}

--- a/www/.astro/settings.json
+++ b/www/.astro/settings.json
@@ -1,0 +1,5 @@
+{
+	"_variables": {
+		"lastUpdateCheck": 1724129638164
+	}
+}

--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -5,10 +5,14 @@ import { fetchGithub } from "../../utils/fetchGithub";
 let githubStars = 23000;
 
 try {
-  (await fetchGithub("https://api.github.com/repos/t3-oss/create-t3-app", {
-    throwIfNoAuth: false,
-    fetchType: "repo",
-  }).then((data) => data?.stargazers_count)) ?? 23000;
+  const fetchedStars = await fetchGithub(
+    "https://api.github.com/repos/t3-oss/create-t3-app",
+    {
+      throwIfNoAuth: false,
+      fetchType: "repo",
+    },
+  ).then((data) => data?.stargazers_count);
+  githubStars = fetchedStars ?? 23000;
 } catch (e) {
   console.error("unable to fetch from github", e);
 }

--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -2,7 +2,7 @@
 import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
 import { fetchGithub } from "../../utils/fetchGithub";
 
-let githubStars = 23000;
+let githubStars = 25000;
 
 try {
   const fetchedStars = await fetchGithub(
@@ -13,7 +13,7 @@ try {
     },
   ).then((data) => data?.stargazers_count);
 
-  githubStars = fetchedStars ?? 23000;
+  githubStars = fetchedStars ?? 25000;
 } catch (e) {
   console.error("unable to fetch from github", e);
 }

--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -12,12 +12,14 @@ try {
       fetchType: "repo",
     },
   ).then((data) => data?.stargazers_count);
+
   githubStars = fetchedStars ?? 23000;
 } catch (e) {
   console.error("unable to fetch from github", e);
 }
 
 const ONE_HOUR = 1 * 60 * 60;
+
 Astro.response.headers.set("Cache-Control", `public, max-age=${ONE_HOUR}`);
 
 const { pathname } = Astro.url;


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The GitHub star count was not displaying correctly. Previously, the "githubStars" in "githubicon.astro" file variable was not being updated with the fetched star count, causing the display to remain at the fallback value of "23K."

_[Short description of what has changed]_

Updated the code to correctly display GitHub star. The "githubStars" variable now correctly reflects the fetched star count instead of using a fixed fallback value, ensuring accurate formatting and display of large numbers.

---

## Screenshots

### Before:

![Screenshot 2024-08-22 205959](https://github.com/user-attachments/assets/221cde82-f8c6-47b1-a3c3-41ad771f52b7)

### After:

![Screenshot 2024-08-22 210005](https://github.com/user-attachments/assets/5793506b-5d72-403a-8379-880b2be63688)


💯
