### PR TITLE
fix: resolved database startup script not checking docker daemon status  @0pilatos0

### DIFF
--- a/.changeset/violet-elephants-sit.md
+++ b/.changeset/violet-elephants-sit.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Resolved issue where database startup script did not check for docker daemon being up and running

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -16,6 +16,11 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker deamon is not up and running. Please start docker and try again."
+  exit 1
+fi
+
 if [ "$(docker ps -q -f name=$DB_CONTAINER_NAME)" ]; then
   echo "Database container '$DB_CONTAINER_NAME' already running"
   exit 0

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -17,7 +17,7 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 if ! docker info > /dev/null 2>&1; then
-  echo "Docker deamon is not up and running. Please start docker and try again."
+  echo "Docker daemon is not running. Please start Docker and try again."
   exit 1
 fi
 

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -16,6 +16,11 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
+if ! docker info > /dev/null 2>&1; then
+  echo "Docker daemon is not running. Please start Docker and try again."
+  exit 1
+fi
+
 if [ "$(docker ps -q -f name=$DB_CONTAINER_NAME)" ]; then
   echo "Database container '$DB_CONTAINER_NAME' already running"
   exit 0


### PR DESCRIPTION
Closes #1974

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

_added an extra check in the initial steps of the start-database.sh script to check if the docker daemon is up and running to prevent the script from continuing with for example generating the password_

---

## Examples

before:
```
❯ ./start-database.sh
Cannot connect to the Docker daemon at unix:///Users/paulvanderlei/.docker/run/docker.sock. Is the docker daemon running?
Cannot connect to the Docker daemon at unix:///Users/paulvanderlei/.docker/run/docker.sock. Is the docker daemon running?
You are using the default database password
Should we generate a random password for you? [y/N]:
```
after:
```
❯ ./start-database.sh
Docker deamon is not up and running. Please start docker and try again.
```


💯
