### PR TITLE
fix: Added a condition, if docker is alive or not.  #1983

### DIFF
--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -16,6 +16,11 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
+if ! [ -x "$(command -v docker info)" ]; then
+  echo -e "Docker is not runnning. Please start docker and try again. If you are on WSL o docker desktop to enable docker on WSL"
+  exit 1
+fi
+
 if [ "$(docker ps -q -f name=$DB_CONTAINER_NAME)" ]; then
   echo "Database container '$DB_CONTAINER_NAME' already running"
   exit 0

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -17,7 +17,7 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 if ! [ -x "$(command -v docker info)" ]; then
-  echo -e "Docker is not runnning. Please start docker and try again. If you are on WSL o docker desktop to enable docker on WSL"
+  echo -e "Docker is not runnning. Please start docker and try again. If you are on WSL open docker desktop to enable docker on WSL"
   exit 1
 fi
 

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -16,6 +16,11 @@ if ! [ -x "$(command -v docker)" ]; then
   exit 1
 fi
 
+if ! [ -x "$(command -v docker info)" ]; then
+  echo -e "Docker is not runnning. Please start docker and try again. If you are WSL open docker desktop to enable docker on WSL"
+  exit 1
+fi
+
 if [ "$(docker ps -q -f name=$DB_CONTAINER_NAME)" ]; then
   echo "Database container '$DB_CONTAINER_NAME' already running"
   exit 0

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -17,7 +17,7 @@ if ! [ -x "$(command -v docker)" ]; then
 fi
 
 if ! [ -x "$(command -v docker info)" ]; then
-  echo -e "Docker is not runnning. Please start docker and try again. If you are WSL open docker desktop to enable docker on WSL"
+  echo -e "Docker is not runnning. Please start docker and try again. If you are on WSL open docker desktop to enable docker on WSL"
   exit 1
 fi
 


### PR DESCRIPTION
This caused problems when docker was not running which resulted in the CLI misinforming me that the database was already running. But it wasn't.

Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

_[Short description of what has changed]_
Added a simple condition to run `docker info` to check if the docker daemon is actually running or not.
---

## Screenshots

_[Screenshots]_
![image](https://github.com/user-attachments/assets/2411297d-5111-4d90-8fd1-8176880cb754)

In this image you can see that the both of the execution of `start-database.sh` are successful. But the second one should fail because I killed the docker daemon but the CLI wasn't able to pick it up.
💯
