### PR TITLE
fix: Sanitize project name for WSL compatibility while running start-database.sh

### DIFF
--- a/cli/src/installers/dbContainer.ts
+++ b/cli/src/installers/dbContainer.ts
@@ -5,6 +5,13 @@ import { PKG_ROOT } from "~/consts.js";
 import { type Installer } from "~/installers/index.js";
 import { parseNameAndPath } from "~/utils/parseNameAndPath.js";
 
+// Sanitizes a project name to ensure it adheres to Docker container naming conventions.
+const sanitizeName = (name: string): string => {
+  return name
+    .replace(/[^a-zA-Z0-9_.-]/g, "_") // Replace invalid characters with underscores
+    .toLowerCase(); // Convert to lowercase for consistency
+};
+
 export const dbContainerInstaller: Installer = ({
   projectDir,
   databaseProvider,
@@ -18,11 +25,14 @@ export const dbContainerInstaller: Installer = ({
   const scriptDest = path.join(projectDir, "start-database.sh");
   // for configuration with postgresql and mysql when project is created with '.' project name
   const [projectNameParsed] =
-    projectName == "." ? parseNameAndPath(projectDir) : [projectName];
+    projectName === "." ? parseNameAndPath(projectDir) : [projectName];
+
+  // Sanitize the project name for Docker container usage
+  const sanitizedProjectName = sanitizeName(projectNameParsed);
 
   fs.writeFileSync(
     scriptDest,
-    scriptText.replaceAll("project1", projectNameParsed)
+    scriptText.replaceAll("project1", sanitizedProjectName)
   );
   fs.chmodSync(scriptDest, "755");
 };


### PR DESCRIPTION
Closes #1928  

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog
- Added sanitizeName function to enforce Docker naming conventions by sanitizing project names.
- Updated dbContainerInstaller to sanitize the parsed project name before writing to the script.
- Modified replacement logic in fs.writeFileSync to use the sanitized project name instead of the placeholder "project1."

---

## Screenshots

_[Screenshots]_

💯
