### PR TITLE
docs: added --appRouter CLI flag to docs

### DIFF
--- a/www/src/pages/en/installation.mdx
+++ b/www/src/pages/en/installation.mdx
@@ -58,6 +58,7 @@ For our CI, we have some experimental flags that allow you to scaffold any app w
 | `--nextAuth`              | Include NextAuth.js in the project           |
 | `--tailwind`              | Include Tailwind CSS in the project          |
 | `--dbProvider [provider]` | Include a configured database in the project |
+| `--appRouter`             | Use Next.js App Router in the project        |
 
 <Callout type="warning">
   If you don't provide the `CI` flag, the rest of these flags have no effect.


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Update the docs to include the "--appRouter" cli flag as an option.

---

## Screenshots

Before:
![Screenshot 2024-10-25 at 11 17 04 PM](https://github.com/user-attachments/assets/c2c778e9-fc07-4423-805d-ea7ecd231fa0)

After:
![Screenshot 2024-10-25 at 11 15 59 PM](https://github.com/user-attachments/assets/01a61215-f870-4939-888a-11b74f0ca2e3)


💯
