### PR TITLE
fix: crypto not defined in cli envVars.ts. t3-oss/create-t3-app#2009

### DIFF
--- a/.changeset/strange-sheep-argue.md
+++ b/.changeset/strange-sheep-argue.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Added an import for crypto in the cli envVars.ts to support older node versions.

--- a/cli/src/installers/envVars.ts
+++ b/cli/src/installers/envVars.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import path from "path";
 import fs from "fs-extra";
 


### PR DESCRIPTION
Closes #2009

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

Added the import of crypto from 'node:crypto' to `envVars.ts`

---

## Screenshots

_[Screenshots]_

💯
