### PR TITLE
feat(tsconfig): enable verbatimModuleSyntax for type imports

### DIFF
--- a/cli/template/base/tsconfig.json
+++ b/cli/template/base/tsconfig.json
@@ -8,6 +8,7 @@
     "resolveJsonModule": true,
     "moduleDetection": "force",
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
 
     /* Strictness */
     "strict": true,


### PR DESCRIPTION
Closes #<issue>

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

This PR enables the `verbatimModuleSyntax` option in the `tsconfig.json` to automatically prefix `type` to type imports. Since we have the `[@typescript-eslint/consistent-type-imports]` rule enabled, it was becoming tedious to manually add the type keyword for every type import.

💯
