### PR TITLE
docs: fix drizzle links in folder structure

### DIFF
--- a/www/src/pages/en/folder-structure-app.mdx
+++ b/www/src/pages/en/folder-structure-app.mdx
@@ -96,14 +96,14 @@ The `db` folder contains the Drizzle client and schema. Note that drizzle also r
 
 #### `src/server/db/index.ts`
 
-The `index.ts` file is used to instantiate the Drizzle client at global scope. See [Drizzle usage](usage/drizzle#drizzle-client) and [best practices for using Drizzle with Next.js](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices) for more information.
+The `index.ts` file is used to instantiate the Drizzle client at global scope. See [Drizzle usage](usage/drizzle#drizzle-client) for more information.
 
 </div>
 <div data-components="drizzle">
 
 #### `src/server/db/schema.ts`
 
-The `schema.ts` file is used to define the database schema. See [Drizzle usage](usage/drizzle#drizzle-client) and [best practices for using Drizzle with Next.js](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices) for more information.
+The `schema.ts` file is used to define the database schema. See [Drizzle usage](usage/drizzle#drizzle-client) and [Drizzle schema docs](https://orm.drizzle.team/docs/sql-schema-declaration) for more information.
 
 </div>
 <div data-components="trpc">

--- a/www/src/pages/en/folder-structure-pages.mdx
+++ b/www/src/pages/en/folder-structure-pages.mdx
@@ -96,14 +96,14 @@ The `db` folder contains the Drizzle client and schema. Note that drizzle also r
 
 #### `src/server/db/index.ts`
 
-The `index.ts` file is used to instantiate the Drizzle client at global scope. See [Drizzle usage](usage/drizzle#drizzle-client) and [best practices for using Drizzle with Next.js](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices) for more information.
+The `index.ts` file is used to instantiate the Drizzle client at global scope. See [Drizzle usage](usage/drizzle#drizzle-client) for more information.
 
 </div>
 <div data-components="drizzle">
 
 #### `src/server/db/schema.ts`
 
-The `schema.ts` file is used to define the database schema. See [Drizzle usage](usage/drizzle#drizzle-client) and [best practices for using Drizzle with Next.js](https://www.prisma.io/docs/guides/database/troubleshooting-orm/help-articles/nextjs-prisma-client-dev-practices) for more information.
+The `schema.ts` file is used to define the database schema. See [Drizzle usage](usage/drizzle#drizzle-client) and [Drizzle schema docs](https://orm.drizzle.team/docs/sql-schema-declaration) for more information.
 
 </div>
 <div data-components="trpc">


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

There were incorrect links to Prisma docs in Drizzle sections in both folder structure pages.
Correct Drizzle docs links were added when applicable, and incorrect Prisma links were removed.

---

## Screenshots

![image](https://github.com/user-attachments/assets/838582e4-cbcf-41ce-b33d-799080fbf6ea)
