### PR TITLE
fix: prevent start-database.sh from creating .env-e, fixes #2060

### DIFF
--- a/.changeset/sour-pots-juggle.md
+++ b/.changeset/sour-pots-juggle.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix start-database.sh to not create an `.env-e` file, which is not gitignored, thus preventing exposure of auth secret, fixes #2060

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -7,7 +7,7 @@ name: PR Checks
 on:
   pull_request_target:
     branches: ["*"]
-    types: ["opened", "synchronize"]
+    types: ["opened", "edited", "synchronize"]
 
 jobs:
   lint-pr-title:

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -47,7 +47,7 @@ if [ "$DB_PASSWORD" == "password" ]; then
   fi
   # Generate a random URL-safe password
   DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
-  sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
+  sed -i '' "s#:password@#:$DB_PASSWORD@#" .env
 fi
 
 docker run -d \

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -48,7 +48,7 @@ if [ "$DB_PASSWORD" = "password" ]; then
   fi
   # Generate a random URL-safe password
   DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
-  sed -i -e "s#:password@#:$DB_PASSWORD@#" .env
+  sed -i '' "s#:password@#:$DB_PASSWORD@#" .env
 fi
 
 docker run -d \


### PR DESCRIPTION
Closes #2060 

## ✅ Checklist

- [X] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

fix start-database.sh to not create an `.env-e` file, which is not gitignored, thus preventing exposure of auth secret, fixes #2060

---

## Screenshots

before:
<img width="171" alt="image" src="https://github.com/user-attachments/assets/d7343e5c-533e-4da7-8285-e04211b94010" />

after:
<img width="168" alt="image" src="https://github.com/user-attachments/assets/5ad23f38-3cc4-4f59-959e-db3a51bfdd67" />


💯
