### PR TITLE
fix: documentation button now rediretcs instead of downloading

### DIFF
--- a/.changeset/loud-actors-return.md
+++ b/.changeset/loud-actors-return.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fixed Github issue #2078 related to documentation button downloading istead of redirecting. Changed it by not including the download prop in "download" is falsy. Don't be too harsh, this is my first contribution in my life.

--- a/www/src/components/landingPage/button.astro
+++ b/www/src/components/landingPage/button.astro
@@ -36,7 +36,7 @@ const specialHoverClass = specialHover
   target={openInNewTab ? "_blank" : "_self"}
   rel="noopener noreferrer"
   class={`${specialHoverClass} ${roundedClass} ${variantClass} ${className} inline-flex items-center px-3 lg:px-4 lg:py-3 md:px-5 py-2 text-sm md:text-base font-semibold cursor-pointer hover:no-underline transition-colors`}
-  {...(download ? { download } : {})}
+  {...download ? { download } : {}}
 >
   <slot />
 </a>

--- a/www/src/components/landingPage/button.astro
+++ b/www/src/components/landingPage/button.astro
@@ -36,7 +36,7 @@ const specialHoverClass = specialHover
   target={openInNewTab ? "_blank" : "_self"}
   rel="noopener noreferrer"
   class={`${specialHoverClass} ${roundedClass} ${variantClass} ${className} inline-flex items-center px-3 lg:px-4 lg:py-3 md:px-5 py-2 text-sm md:text-base font-semibold cursor-pointer hover:no-underline transition-colors`}
-  download={download}
+  {...(download ? { download } : {})}
 >
   <slot />
 </a>


### PR DESCRIPTION
Closes #2078<issue>

## ✅ Checklist

- [x ] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x ] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x ] I performed a functional test on my final commit

---

## Changelog

_The "downlaod" prop  (in www/src/components/landingPage/button.astro) is now only included if "download" is truthy, instead of being set to "downlaod='false'" when falsy, which resulted in the button always downloading_

💯
