### PR TITLE
fix: format breaks npm and edge case for pnpm #2080

### DIFF
--- a/.changeset/neat-hounds-develop.md
+++ b/.changeset/neat-hounds-develop.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fixes installation issues with npm and when not installing packages

--- a/cli/src/helpers/format.ts
+++ b/cli/src/helpers/format.ts
@@ -21,11 +21,11 @@ export const formatProject = async ({
   const spinner = ora("Running format command\n").start();
 
   if (eslint) {
-    await execa(pkgManager, ["format:write"], {
+    await execa(pkgManager, ["run", "format:write"], {
       cwd: projectDir,
     });
   } else if (biome) {
-    await execa(pkgManager, ["check:unsafe"], {
+    await execa(pkgManager, ["run", "check:unsafe"], {
       cwd: projectDir,
     });
   }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -84,14 +84,14 @@ const main = async () => {
 
   if (!noInstall) {
     await installDependencies({ projectDir });
-  }
 
-  await formatProject({
-    pkgManager,
-    projectDir,
-    eslint: packages.includes("eslint"),
-    biome: packages.includes("biome"),
-  });
+    await formatProject({
+      pkgManager,
+      projectDir,
+      eslint: packages.includes("eslint"),
+      biome: packages.includes("biome"),
+    });
+  }
 
   if (!noGit) {
     await initializeGit(projectDir);


### PR DESCRIPTION
Closes #2080 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

fixes an issue with npm and pnpm when installing.
* npm: all cases
* pnpm: when not allowing `pnpm install` to be run

---

## Screenshots

![Screenshot 2025-03-23 at 7 01 13 AM](https://github.com/user-attachments/assets/562bd514-d146-4909-9977-ee6809106f85)


💯
