### PR TITLE
fix: added missing dependencies needed for VS Code ESLint Plugin when using pnpm

### DIFF
--- a/.changeset/twelve-dots-kiss.md
+++ b/.changeset/twelve-dots-kiss.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fixes ESLint loading by adding two missing required packages

--- a/cli/src/installers/dependencyVersionMap.ts
+++ b/cli/src/installers/dependencyVersionMap.ts
@@ -44,7 +44,9 @@ export const dependencyVersionMap = {
   "prettier-plugin-tailwindcss": "^0.6.11",
   eslint: "^9.23.0",
   "eslint-config-next": "^15.2.3",
+  "@next/eslint-plugin-next": "^15.2.3",
   "eslint-plugin-drizzle": "^0.2.3",
+  "eslint-plugin-react-hooks": "^5.2.0",
   "typescript-eslint": "^8.27.0",
 } as const;
 export type AvailableDependencies = keyof typeof dependencyVersionMap;

--- a/cli/src/installers/eslint.ts
+++ b/cli/src/installers/eslint.ts
@@ -13,8 +13,10 @@ export const dynamicEslintInstaller: Installer = ({ projectDir, packages }) => {
     "prettier",
     "eslint",
     "eslint-config-next",
+    "eslint-plugin-react-hooks",
     "typescript-eslint",
     "@eslint/eslintrc",
+    "@next/eslint-plugin-next",
   ];
 
   if (packages?.tailwind.inUse) {

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -17,9 +17,7 @@ const getQueryClient = () => {
     return createQueryClient();
   }
   // Browser: use singleton pattern to keep the same query client
-  if (!clientQueryClientSingleton) {
-    clientQueryClientSingleton = createQueryClient();
-  }
+  clientQueryClientSingleton ??= createQueryClient();
   return clientQueryClientSingleton;
 };
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

ESLint was not loading correctly due to two missing packages:

- `eslint-plugin-react-hooks`
- `@next/eslint-plugin-next`

---

## Screenshots

### Before:
```cli
[Error - 7:43:24 PM] Failed to load plugin 'react-hooks' declared in ' » eslint-config-next/core-web-vitals »
     '\node_modules\eslint-config-next\index.js': Cannot find module 'eslint-plugin-react-hooks'

[Error - 7:45:47 PM] Failed to load plugin '@next/next' declared in ' » eslint-config-next/core-web-vitals »
     '\node_modules\eslint-config-next\index.js': Cannot find module '@next/eslint-plugin-next'
```

### After:
```cli
[Info  - 7:48:39 PM] ESLint server is starting.
[Info  - 7:48:40 PM] ESLint server running in node v20.18.3
[Info  - 7:48:40 PM] ESLint server is running.
```

💯
