### PR TITLE
fix: remove empty string from sed args when not on Darwin

### DIFF
--- a/.changeset/fast-hounds-invent.md
+++ b/.changeset/fast-hounds-invent.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fix database start scripts to work better on linux

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -70,7 +70,12 @@ if [ "$DB_PASSWORD" == "password" ]; then
   fi
   # Generate a random URL-safe password
   DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
-  sed -i '' "s#:password@#:$DB_PASSWORD@#" .env
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS requires an empty string to be passed with the `i` flag
+    sed -i '' "s#:password@#:$DB_PASSWORD@#" .env
+  else
+    sed -i "s#:password@#:$DB_PASSWORD@#" .env
+  fi
 fi
 
 $DOCKER_CMD run -d \

--- a/cli/template/extras/start-database/mysql.sh
+++ b/cli/template/extras/start-database/mysql.sh
@@ -17,7 +17,7 @@ source .env
 DB_PASSWORD=$(echo "$DATABASE_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
 DB_PORT=$(echo "$DATABASE_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 DB_NAME=$(echo "$DATABASE_URL" | awk -F'/' '{print $4}')
-DB_CONTAINER_NAME="$DB_NAME-postgres"
+DB_CONTAINER_NAME="$DB_NAME-mysql"
 
 if ! [ -x "$(command -v docker)" ] && ! [ -x "$(command -v podman)" ]; then
   echo -e "Docker or Podman is not installed. Please install docker or podman and try again.\nDocker install guide: https://docs.docker.com/engine/install/\nPodman install guide: https://podman.io/getting-started/installation"

--- a/cli/template/extras/start-database/postgres.sh
+++ b/cli/template/extras/start-database/postgres.sh
@@ -71,7 +71,12 @@ if [ "$DB_PASSWORD" = "password" ]; then
   fi
   # Generate a random URL-safe password
   DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
-  sed -i '' "s#:password@#:$DB_PASSWORD@#" .env
+  if [[ "$(uname)" == "Darwin" ]]; then
+    # macOS requires an empty string to be passed with the `i` flag
+    sed -i '' "s#:password@#:$DB_PASSWORD@#" .env
+  else
+    sed -i "s#:password@#:$DB_PASSWORD@#" .env
+  fi
 fi
 
 $DOCKER_CMD run -d \


### PR DESCRIPTION
Closes #2099 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

The start database bash scripts now check if you are running a Darwin machine. If so, it uses the empty string arg for `sed`, but if not, it omits it.

I also updated the name of the mysql db to include `mysql` instead of `postgres`

---

## Screenshots

BEFORE (postgres):
![20250405_18h16m40s_grim](https://github.com/user-attachments/assets/fc3d5f11-0705-4fe6-a8c2-5934d6b39d71)

BEFORE (mysql):
![20250405_18h18m18s_grim](https://github.com/user-attachments/assets/ec691e5d-3bdb-441e-a58b-9e2b1ef5e129)

AFTER (postgres):
![20250405_18h20m29s_grim](https://github.com/user-attachments/assets/bba7da18-fd27-4647-b7ea-3fc5804b58e9)

AFTER (mysql):
![20250405_18h21m43s_grim](https://github.com/user-attachments/assets/87ce0257-2af3-4c41-be4c-df370810bf54)


💯
