### PR TITLE
fix: Fix log saying eslint is ran when prettier is ran

### DIFF
--- a/.changeset/strong-poems-sing.md
+++ b/.changeset/strong-poems-sing.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Fix log saying eslint is ran when prettier is ran

--- a/cli/src/helpers/format.ts
+++ b/cli/src/helpers/format.ts
@@ -17,7 +17,7 @@ export const formatProject = async ({
   eslint: boolean;
   biome: boolean;
 }) => {
-  logger.info(`Formatting project with ${eslint ? "eslint" : "biome"}...`);
+  logger.info(`Formatting project with ${eslint ? "prettier" : "biome"}...`);
   const spinner = ora("Running format command\n").start();
 
   if (eslint) {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [X] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] I performed a functional test on my final commit

---

## Changelog

Changed log that said that eslint was ran when prettier was ran.
