### PR TITLE
fix: resolve BetterAuth and Drizzle Kit dependency conflict

### DIFF
--- a/.changeset/resolve-betterauth-drizzle-conflict.md
+++ b/.changeset/resolve-betterauth-drizzle-conflict.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix: resolve BetterAuth and Drizzle Kit dependency conflict

--- a/cli/package.json
+++ b/cli/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@auth/drizzle-adapter": "^1.1.0",
     "@auth/prisma-adapter": "^1.6.0",
+    "@better-auth/drizzle-adapter": "^1.6.6",
     "@libsql/client": "^0.14.0",
     "@planetscale/database": "^1.19.0",
     "@prisma/adapter-planetscale": "^6.6.0",
@@ -78,8 +79,8 @@
     "@types/fs-extra": "^11.0.4",
     "@types/gradient-string": "^1.1.6",
     "@types/node": "^24.10.1",
-    "better-auth": "^1.3",
-    "drizzle-kit": "^0.30.5",
+    "better-auth": "^1.6.6",
+    "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.41.0",
     "mysql2": "^3.11.0",
     "next": "^15.5.9",

--- a/cli/src/installers/betterAuth.ts
+++ b/cli/src/installers/betterAuth.ts
@@ -17,7 +17,7 @@ export const betterAuthInstaller: Installer = ({
 
   const deps: AvailableDependencies[] = ["better-auth"];
   if (usingPrisma) deps.push("@auth/prisma-adapter");
-  if (usingDrizzle) deps.push("@auth/drizzle-adapter");
+  if (usingDrizzle) deps.push("@better-auth/drizzle-adapter");
 
   addPackageDependency({
     projectDir,

--- a/cli/src/installers/dependencyVersionMap.ts
+++ b/cli/src/installers/dependencyVersionMap.ts
@@ -9,7 +9,8 @@ export const dependencyVersionMap = {
   "@auth/drizzle-adapter": "^1.7.2",
 
   // Better-Auth
-  "better-auth": "^1.3",
+  "better-auth": "^1.6.6",
+  "@better-auth/drizzle-adapter": "^1.6.6",
 
   // Prisma
   prisma: "^6.6.0",
@@ -17,7 +18,7 @@ export const dependencyVersionMap = {
   "@prisma/adapter-planetscale": "^6.6.0",
 
   // Drizzle
-  "drizzle-kit": "^0.30.5",
+  "drizzle-kit": "^0.31.10",
   "drizzle-orm": "^0.41.0",
   mysql2: "^3.11.0",
   "@planetscale/database": "^1.19.0",

--- a/cli/template/extras/src/server/better-auth/config/with-drizzle.ts
+++ b/cli/template/extras/src/server/better-auth/config/with-drizzle.ts
@@ -1,5 +1,5 @@
 import { betterAuth } from "better-auth";
-import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { nextCookies } from "better-auth/next-js";
 
 import { env } from "~/env";


### PR DESCRIPTION
- Update better-auth from ^1.3 to ^1.6.6 (latest)
- Add @better-auth/drizzle-adapter (new separate adapter package)
- Update drizzle-kit from ^0.30.5 to ^0.31.10 (satisfies peer dependency)
- Fix template import to use @better-auth/drizzle-adapter